### PR TITLE
Extract handlers from routes.js

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,77 @@
+// Store, retrieve, and delete metadata envelopes.
+
+var
+  config = require('./config'),
+  connection = require('./connection'),
+  logging = require('./logging');
+
+var log = logging.getLogger(config.content_log_level());
+
+/**
+ * @description Retrieve content from the store by content ID.
+ */
+exports.retrieve = function (req, res, next) {
+  log.debug("Requesting content ID: [" + req.params.id + "]");
+
+  var source = connection.client.download({
+    container: config.content_container(),
+    remote: encodeURIComponent(req.params.id)
+  });
+
+  // This directly sends the response to the caller, long term we'll
+  // probably not want to do this, but it allows the prototype to get functional
+  //
+  source.pipe(res);
+
+  next();
+};
+
+/**
+ * @description Store new content into the content service.
+ *
+ * Payload must be in the form of:
+ *
+ * {
+ *   id: "https://github.com/deconst/deconst-docs/issues/16", // Full url of content
+ *   body: { }
+ * }
+ *
+ */
+exports.store = function (req, res, next) {
+  log.info("Storing content with ID: [" + req.body.id + "]");
+
+  var dest = connection.client.upload({
+    container: config.content_container(),
+    remote: encodeURIComponent(req.body.id)
+  });
+
+  dest.on('success', function () {
+    res.status(200);
+    res.send();
+    next();
+  });
+
+  // For now we're just going to JSON.stringify the body directly up to cloud files
+  // longer term we might do multi-plexing or async.parallel to different stores
+  dest.end(JSON.stringify(req.body.body));
+};
+
+/**
+ * @description Delete a piece of previously stored content by content ID.
+ */
+exports.delete = function (req, res, next) {
+  log.info("Deleting content with ID [" + req.params.id + "]");
+
+  connection.client.removeFile(config.content_container(), encodeURIComponent(req.params.id), function (err) {
+    if (err) {
+      res.status(err.statusCode);
+      res.send();
+      next();
+      return;
+    }
+
+    res.status(200);
+    res.send();
+    next();
+  });
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,24 +2,18 @@ var
   pkgcloud = require('pkgcloud'),
   config = require('./config'),
   connection = require('./connection'),
-  logging = require('./logging'),
+  logging = require('./logging');
+
+// Handlers
+var
+  version = require('./version'),
   assets = require('./assets');
 
 var log = logging.getLogger(config.content_log_level());
 
 exports.loadRoutes = function (server) {
 
-  /**
-   * @description gets the version of the current service
-   */
-  server.get('/version', function (req, res, next) {
-    res.send({
-      service: config.info.name,
-      version: config.info.version,
-      commit: config.commit
-    });
-    next();
-  });
+  server.get('/version', version.report);
 
   /**
    * @description Allows retrieving content from the content service

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,4 @@
 var
-  pkgcloud = require('pkgcloud'),
   config = require('./config'),
   connection = require('./connection'),
   logging = require('./logging');
@@ -7,6 +6,7 @@ var
 // Handlers
 var
   version = require('./version'),
+  content = require('./content'),
   assets = require('./assets');
 
 var log = logging.getLogger(config.content_log_level());
@@ -15,74 +15,9 @@ exports.loadRoutes = function (server) {
 
   server.get('/version', version.report);
 
-  /**
-   * @description Allows retrieving content from the content service
-   */
-  server.get('/content/:id', function (req, res, next) {
-    log.debug("Requesting content ID: [" + req.params.id + "]");
-
-    var source = connection.client.download({
-      container: config.content_container(),
-      remote: encodeURIComponent(req.params.id)
-    });
-
-    // This directly sends the response to the caller, long term we'll
-    // probably not want to do this, but it allows the prototype to get functional
-    //
-    source.pipe(res);
-
-    next();
-  });
-
-  /**
-   * @description Allows storing new content into the content service
-   *
-   * Payload must be in the form of:
-   *
-   * {
-   *   id: "https://github.com/deconst/deconst-docs/issues/16", // Full url of content
-   *   body: { }
-   * }
-   *
-   */
-  server.put('/content', function (req, res, next) {
-    log.info("Storing content with ID: [" + req.body.id + "]");
-
-    var dest = connection.client.upload({
-      container: config.content_container(),
-      remote: encodeURIComponent(req.body.id)
-    });
-
-    dest.on('success', function () {
-      res.status(200);
-      res.send();
-      next();
-    });
-
-    // For now we're just going to JSON.stringify the body directly up to cloud files
-    // longer term we might do multi-plexing or async.parallel to different stores
-    dest.end(JSON.stringify(req.body.body));
-  });
-
-  /**
-   * @description Delete a piece of content by id
-   */
-  server.del('/content/:id', function (req, res, next) {
-    log.info("Deleting content with ID [" + req.params.id + "]");
-
-    connection.client.removeFile(config.content_container(), encodeURIComponent(req.params.id), function (err) {
-      if (err) {
-        res.status(err.statusCode);
-        res.send();
-        next();
-        return;
-      }
-
-      res.status(200);
-      res.send();
-      next();
-    });
-  });
+  server.get('/content/:id', content.retrieve);
+  server.put('/content', content.store);
+  server.del('/content/:id', content.delete);
 
   server.post('/assets', assets.accept);
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,18 +1,10 @@
-var
-  config = require('./config'),
-  connection = require('./connection'),
-  logging = require('./logging');
-
 // Handlers
 var
   version = require('./version'),
   content = require('./content'),
   assets = require('./assets');
 
-var log = logging.getLogger(config.content_log_level());
-
 exports.loadRoutes = function (server) {
-
   server.get('/version', version.report);
 
   server.get('/content/:id', content.retrieve);

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,15 @@
+// Echo the service name, version, and commit.
+
+var config = require('./config');
+
+/**
+ * @description gets the version of the current service
+ */
+exports.report = function (req, res, next) {
+  res.send({
+    service: config.info.name,
+    version: config.info.version,
+    commit: config.commit
+  });
+  next();
+};


### PR DESCRIPTION
Rather than defining request handlers directly in `src/routes.js`, extract groups of related handler functions into separate source files, for better organization.
