### PR TITLE
Move the content ID to the URL for content storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,17 @@ Report the service name, version, and git commit.
 }
 ```
 
-### `PUT /content`
+### `PUT /content/:id`
 
 Store and index content with a specific URL-encoded *content ID*.
 
 *Request*
 
-The request payload must be a JSON document matching the following schema:
+The request payload must be a valid Deconst metadata envelope in JSON form.
 
 ```json
 {
-  "id": "https://github.com/deconst/deconst-docs/content/id/here",
-  "body": { }
+  "body": "<h1>page content</h1> <p>as raw HTML</p>"
 }
 ```
 

--- a/src/content.js
+++ b/src/content.js
@@ -38,11 +38,11 @@ exports.retrieve = function (req, res, next) {
  *
  */
 exports.store = function (req, res, next) {
-  log.info("Storing content with ID: [" + req.body.id + "]");
+  log.info("Storing content with ID: [" + req.params.id + "]");
 
   var dest = connection.client.upload({
     container: config.content_container(),
-    remote: encodeURIComponent(req.body.id)
+    remote: encodeURIComponent(req.params.id)
   });
 
   dest.on('success', function () {
@@ -51,9 +51,9 @@ exports.store = function (req, res, next) {
     next();
   });
 
-  // For now we're just going to JSON.stringify the body directly up to cloud files
+  // For now we're just going to write the body directly up to cloud files
   // longer term we might do multi-plexing or async.parallel to different stores
-  dest.end(JSON.stringify(req.body.body));
+  req.pipe(dest);
 };
 
 /**

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,7 +8,7 @@ exports.loadRoutes = function (server) {
   server.get('/version', version.report);
 
   server.get('/content/:id', content.retrieve);
-  server.put('/content', content.store);
+  server.put('/content/:id', content.store);
   server.del('/content/:id', content.delete);
 
   server.post('/assets', assets.accept);


### PR DESCRIPTION
It feels a little cleaner to me to have the content ID as a URL path parameter for the content `PUT` call. It's more consistent with the other content handlers and with standard PUT semantics (as I understand them). It also lets us treat the entire request body as the document to store, which is more convenient.
