### PR TITLE
Don't use bodyParser universally.

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,8 +32,7 @@ connection.setup(config, function (err) {
       log.verbose(req.method + ' ' + req.url);
       next();
     })
-    .use(restify.fullResponse())
-    .use(restify.bodyParser());
+    .use(restify.fullResponse());
 
   routes.loadRoutes(server);
 

--- a/src/content.js
+++ b/src/content.js
@@ -45,7 +45,7 @@ exports.store = function (req, res, next) {
 
   // For now, we're just going to write the body directly up to Cloud Files.
   // Longer term, we'll validate its structure and use async.parallel to upload it to different stores.
-  dest.end(req.body);
+  req.pipe(dest);
 };
 
 /**


### PR DESCRIPTION
This prevents an issue where bodyParser was consuming a request body, attempting to parse it as JSON, and dying horribly in the middle.

We can add it back in on the specific routes that depend on it.
