### PR TITLE
Use the bodyParser middleware for `/assets`.

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -1,3 +1,5 @@
+var restify = require('restify');
+
 // Handlers
 var
   version = require('./version'),
@@ -11,5 +13,5 @@ exports.loadRoutes = function (server) {
   server.put('/content/:id', content.store);
   server.del('/content/:id', content.delete);
 
-  server.post('/assets', assets.accept);
+  server.post('/assets', restify.bodyParser(), assets.accept);
 };


### PR DESCRIPTION
Looks like we actually do need it there.
