### PR TITLE
Apply a name to assets when requested.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,15 @@ The exact JSON document provided to `PUT /content` will be returned.
 
 An HTTP status of 404 will be returned if the content ID isn't recognized.
 
-### `POST /asset`
+### `POST /asset[?layout=true]`
 
 Fingerprint and publish one or more static assets to a CDN-enabled Cloud Files container. Return the full URLs to the published assets.
 
 *Request*
 
 The request payload must be a `multipart/form-data` file upload containing the assets to upload. The content type of each file must be set appropriately.
+
+If the query parameter `layout=true` is provided, the asset will also be persisted in the *layout asset map* and inserted in the `layouts` object of every outgoing metadata envelope.
 
 *Response*
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The exact JSON document provided to `PUT /content` will be returned.
 
 An HTTP status of 404 will be returned if the content ID isn't recognized.
 
-### `POST /asset[?layout=true]`
+### `POST /asset[?named=true]`
 
 Fingerprint and publish one or more static assets to a CDN-enabled Cloud Files container. Return the full URLs to the published assets.
 
@@ -93,7 +93,7 @@ Fingerprint and publish one or more static assets to a CDN-enabled Cloud Files c
 
 The request payload must be a `multipart/form-data` file upload containing the assets to upload. The content type of each file must be set appropriately.
 
-If the query parameter `layout=true` is provided, the asset will also be persisted in the *layout asset map* and inserted in the `layouts` object of every outgoing metadata envelope.
+If the query parameter `named=true` is provided, each asset's CDN URI will also be persisted in the *layout asset map* with a key derived from its form name and inserted in the `assets` object of every outgoing metadata envelope.
 
 *Response*
 

--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ var
 
 server.name = config.info.name;
 
-connection.setup(config, function (err) {
+connection.setup(function (err) {
   if (err) {
     throw err;
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,17 @@
 ---
+mongo:
+  image: mongo:2.6
 content:
   build: .
   ports:
   - "9000:8080"
+  links:
+  - "mongo:mongo"
   environment:
     RACKSPACE_USERNAME:
     RACKSPACE_APIKEY:
     RACKSPACE_REGION: DFW
     CONTENT_CONTAINER: deconst-dev-content
     ASSET_CONTAINER: deconst-dev-assets
+    MONGODB_URL: mongodb://mongo:27017/content
     CONTENT_LOG_LEVEL: debug

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Ken Perkins <ken.perkins@rackspace.com>",
   "license": "MIT",
   "dependencies": {
+    "JSONStream": "0.10.0",
     "async": "0.9.0",
     "mongodb": "2.0.27",
     "pkgcloud": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "0.9.0",
+    "mongodb": "2.0.27",
     "pkgcloud": "1.1.0",
     "restify": "3.0.0",
     "winston": "0.9.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "author": "Ken Perkins <ken.perkins@rackspace.com>",
   "license": "MIT",
   "dependencies": {
-    "JSONStream": "0.10.0",
     "async": "0.9.0",
     "mongodb": "2.0.27",
     "pkgcloud": "1.1.0",

--- a/script/mongo-cli
+++ b/script/mongo-cli
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+exec docker-compose run --rm mongo \
+  sh -c 'exec mongo "${MONGO_PORT_27017_TCP_ADDR}:${MONGO_PORT_27017_TCP_PORT}/content"'

--- a/src/assets.js
+++ b/src/assets.js
@@ -124,7 +124,7 @@ exports.accept = function (req, res, next) {
     return asset;
   });
 
-  async.map(asset_data, make_asset_handler(req.query.layout), function (err, results) {
+  async.map(asset_data, make_asset_handler(req.query.named), function (err, results) {
     if (err) {
       log.error("Unable to process an asset.", err);
 

--- a/src/assets.js
+++ b/src/assets.js
@@ -39,6 +39,7 @@ function fingerprint_asset(asset, callback) {
     log.debug("Fingerprinted asset [" + asset.name + "] as [" + fingerprinted + "].");
 
     callback(null, {
+      key: asset.key,
       original: asset.name,
       chunks: chunks,
       filename: fingerprinted,
@@ -81,7 +82,7 @@ function publish_asset(asset, callback) {
  *   layouts.
  */
 function name_asset(asset, callback) {
-  log.debug("Naming asset [" + asset.name + "] as [" + asset.key + "].");
+  log.debug("Naming asset [" + asset.original + "] as [" + asset.key + "].");
 
   connection.db.collection("layout_assets").updateOne(
     { key: asset.key },

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,7 @@ var configuration = {
   rackspace_region: null,
   content_container: null,
   asset_container: null,
+  mongodb_url: null,
   content_log_level: "info"
 };
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -66,6 +66,8 @@ function mongo_auth(callback) {
       return;
     }
 
+    log.debug("Connected to MongoDB database at [" + config.mongodb_url() + "].");
+
     exports.db = db;
 
     callback(null);

--- a/src/connection.js
+++ b/src/connection.js
@@ -3,6 +3,7 @@
 var
   async = require('async'),
   pkgcloud = require('pkgcloud'),
+  mongo = require('mongodb'),
   config = require('./config'),
   logging = require('./logging');
 
@@ -55,7 +56,23 @@ function refresh(client, container_name, logical_name, callback) {
   });
 }
 
-exports.setup = function (config, callback) {
+/**
+ * @description Authenticate to MongoDB and export the active MongoDB connection as "db".
+ */
+function mongo_auth(callback) {
+  mongo.MongoClient.connect(config.mongodb_url(), function (err, db) {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    exports.db = db;
+
+    callback(null);
+  });
+}
+
+exports.setup = function (callback) {
   var client = pkgcloud.providers.rackspace.storage.createClient({
     username: config.rackspace_username(),
     apiKey: config.rackspace_apikey(),
@@ -66,5 +83,6 @@ exports.setup = function (config, callback) {
   async.parallel([
     make_container_creator(client, config.content_container(), "content_container", false),
     make_container_creator(client, config.asset_container(), "asset_container", true),
+    mongo_auth
   ], callback);
 };

--- a/src/content.js
+++ b/src/content.js
@@ -14,7 +14,7 @@ var log = logging.getLogger(config.content_log_level());
 function download_content(content_id, callback) {
   var source = connection.client.download({
     container: config.content_container(),
-    remote: encodeURIComponent(req.params.id)
+    remote: encodeURIComponent(content_id)
   });
   var chunks = [];
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -13,5 +13,5 @@ exports.loadRoutes = function (server) {
   server.put('/content/:id', content.store);
   server.del('/content/:id', content.delete);
 
-  server.post('/assets', restify.bodyParser(), assets.accept);
+  server.post('/assets', restify.bodyParser(), restify.queryParser(), assets.accept);
 };


### PR DESCRIPTION
This is necessary to support assets supplied as part of a layout, the second half of deconst/deconst-docs#13.

My goal is that, if you provide an optional `?layout=true` query parameter to an asset upload:

``` bash
curl -s -F assetname=@someasset.jpg http://content:9000/assets?layout=true
```

... an additional key called `assetname` will be provided to the handlebars layout during every page render, with a value that's the SSL URI of the fingerprinted _someasset.jpg_ file on the CDN.
