### PR TITLE
Move assets out of envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The request payload must be a valid Deconst metadata envelope in JSON form.
 
 ```json
 {
+  "title": "Optional page title",
   "body": "<h1>page content</h1> <p>as raw HTML</p>"
 }
 ```
@@ -79,7 +80,14 @@ Access previously stored content by its URL-encoded *content ID*.
 
 *Response: Successful*
 
-The exact JSON document provided to `PUT /content` will be returned.
+```json
+{
+  "assets": {},
+  "envelope": {}
+}
+```
+
+`"envelope"` will be the exact JSON document provided to `PUT /content`. `"assets"` will contain a set of site-wide layout asset variables.
 
 *Response: Unsuccessful*
 

--- a/src/content.js
+++ b/src/content.js
@@ -31,7 +31,7 @@ function download_content(content_id, callback) {
       complete = Buffer.concat(chunks),
       envelope = JSON.parse(complete);
 
-    callback(null, envelope);
+    callback(null, {envelope: envelope});
   });
 }
 
@@ -39,7 +39,7 @@ function download_content(content_id, callback) {
  * @description Inject asset variables included from the /assets endpoint into
  *   an outgoing metadata envelope.
  */
-function inject_asset_vars(envelope, callback) {
+function inject_asset_vars(doc, callback) {
   log.debug("Collecting asset variables to inject into the envelope.");
 
   connection.db.collection("layout_assets").find().toArray(function (err, asset_vars) {
@@ -56,9 +56,9 @@ function inject_asset_vars(envelope, callback) {
       assets[asset_var.key] = asset_var.public_url;
     });
 
-    envelope.assets = assets;
+    doc.assets = assets;
 
-    callback(null, envelope);
+    callback(null, doc);
   });
 }
 
@@ -71,7 +71,7 @@ exports.retrieve = function (req, res, next) {
   async.waterfall([
     async.apply(download_content, req.params.id),
     inject_asset_vars
-  ], function (err, envelope) {
+  ], function (err, doc) {
     if (err) {
       log.error("Failed to retrieve a metadata envelope", err);
 
@@ -83,7 +83,7 @@ exports.retrieve = function (req, res, next) {
     }
 
     res.status(200);
-    res.json(envelope);
+    res.json(doc);
     next();
   });
 };


### PR DESCRIPTION
Fixes #25.

This should make the other things that I need to add to the content service response document less obtrusive.
