### PR TITLE
Protect content manipulation with API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ An HTTP status of 404 will be returned if the content ID isn't recognized.
 
 ### `POST /asset[?named=true]`
 
+**(Authorization required: any user)**
+
 Fingerprint and publish one or more static assets to a CDN-enabled Cloud Files container. Return the full URLs to the published assets.
 
 *Request*

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Issue a newly generated API key. The provided human-friendly name will be used t
 
 ```json
 {
-  "apikey": "6aa856c50e5c8895020ef8d359d29f5d0a41696cdc767fdbce9cabed73fa81bfd387ffea0e01d295abc3c5117e87df6bbd28e21e3314803247692bafccd8ef6b09978aacebac30b758893ec232600599aaf78f279648e8c86c35658ff24579b73884883f0af4bc5f85de25ee776307253fcbd6e5c6d9b16fa414c0f9e167478f"
+  "apikey": "6aa856c50e5c8895020ef8d35..."
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ The request payload must be a valid Deconst metadata envelope in JSON form.
 
 An HTTP status of 200 and an empty response body will be returned when content is accepted successfully.
 
+### `DELETE /content/:id`
+
+**(Authorization required: any user)**
+
+Delete content with a specific URL-encoded *content ID*.
+
+*Response: Successful*
+
+An HTTP status of 204 indicates that the content has been deleted successfully.
+
+*Response: Unsuccessful*
+
+An HTTP status of 404 will be returned if the content ID isn't recognized.
+
 ### `GET /content/:id`
 
 Access previously stored content by its URL-encoded *content ID*.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The content service is configured by passing environment variables to the Docker
  * `RACKSPACE_USERNAME`: **(Required)** the username for your Rackspace account.
  * `RACKSPACE_APIKEY`: **(Required)** the API key for your Rackspace account.
  * `RACKSPACE_REGION`: **(Required)** the Rackspace region for the content service to use.
+ * `ADMIN_APIKEY`: **(Required)** an API key that can be used by administrators or other internal services to issue and revoke API keys.
  * `CONTENT_CONTAINER`: **(Required)** container name to use for the stored metadata envelopes.
  * `ASSET_CONTAINER`: **(Required)** container name to use for published assets.
  * `CONTENT_LOG_LEVEL`: Optional logging level. The valid levels are `TRACE`, `DEBUG`, `VERBOSE`, `INFO` (Default), `WARN`, and `ERROR`.
@@ -38,6 +39,21 @@ Both Cloud Files containers will be created and configured on application launch
 In development mode, docker-compose provides defaults for everything but `RACKSPACE_USERNAME` and `RACKSPACE_APIKEY`.
 
 ## API
+
+### Authorization
+
+Endpoints that require authorization *must* be accompanied by a valid API key. Set the API key in
+an `Authorization` header.
+
+```
+PUT /content/https%3A%2F%2Fgithub.com%2Fsomeuser%2Fsomerepo%2Fsomeid
+Authorization: deconst apikey="12345"
+```
+
+Valid API keys include:
+
+ * The admin API key, as specified by [the service configuration.](#configuration)
+ * User keys issued by the [`POST /keys`](#post-keys) endpoint.
 
 The content service exposes the following API endpoints:
 
@@ -56,6 +72,8 @@ Report the service name, version, and git commit.
 ```
 
 ### `PUT /content/:id`
+
+**(Authorization required: any user)**
 
 Store and index content with a specific URL-encoded *content ID*.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Authorization: deconst apikey="12345"
 Valid API keys include:
 
  * The admin API key, as specified by [the service configuration.](#configuration)
- * User keys issued by the [`POST /keys`](#post-keys) endpoint.
+ * User keys issued by the [`POST /keys`](#post-keysnamedname) endpoint.
 
 The content service exposes the following API endpoints:
 

--- a/README.md
+++ b/README.md
@@ -143,3 +143,35 @@ If the query parameter `named=true` is provided, each asset's CDN URI will also 
   "file2.css": "https://assets.horse/url/for/file2-d2da57e04b0818f7e3dd18da3b73c9b54a73cbe5.css"
 }
 ```
+
+### `POST /keys?named=:name`
+
+**(Authorization required: admin only)**
+
+Issue a newly generated API key. The provided human-friendly name will be used to log actions performed with this key.
+
+*Response: Successful*
+
+```json
+{
+  "apikey": "6aa856c50e5c8895020ef8d359d29f5d0a41696cdc767fdbce9cabed73fa81bfd387ffea0e01d295abc3c5117e87df6bbd28e21e3314803247692bafccd8ef6b09978aacebac30b758893ec232600599aaf78f279648e8c86c35658ff24579b73884883f0af4bc5f85de25ee776307253fcbd6e5c6d9b16fa414c0f9e167478f"
+}
+```
+
+*Response: Unsuccessful*
+
+An HTTP status code of 401 indicates that the request did not contain a valid administrator API key.
+
+### `DELETE /keys/:apikey`
+
+**(Authorization required: admin only)**
+
+Revoke a previously issued user API key.
+
+*Response: Successful*
+
+An HTTP status code of 204 indicates that the API key will no longer be valid.
+
+*Response: Unsuccessful*
+
+An HTTP status code of 401 indicates that the request did not contain a valid administrator API key. A 409 is generated if an administrator attempts to revoke their own key.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ content:
     RACKSPACE_USERNAME:
     RACKSPACE_APIKEY:
     RACKSPACE_REGION: DFW
+    ADMIN_APIKEY: 12345
     CONTENT_CONTAINER: deconst-dev-content
     ASSET_CONTAINER: deconst-dev-assets
     MONGODB_URL: mongodb://mongo:27017/content

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,65 @@
+// Authentication middleware.
+
+var
+  async = require("async"),
+  restify = require("restify"),
+  logging = require("./logging"),
+  config = require("./config"),
+  connection = require("./connection");
+
+var log = logging.getLogger(config.content_log_level());
+
+var credential_rx = /apikey\s*=\s*"?([^"]+)"?/;
+
+/**
+ * @description Extract an API key from a request's parsed Authorization header. Emit an error if
+ *  no such header is present, or if it's not formed correctly.
+ */
+var parse_auth = function (auth, callback) {
+  if (!auth || !Object.keys(auth).length) {
+    return callback(new restify.UnauthorizedError("An API key is required for this endpoint."));
+  }
+
+  if (auth.scheme !== "deconst") {
+    return callback(new restify.InvalidHeaderError("Your Authorization header specifies an incorrect scheme."));
+  }
+
+  var match = credential_rx.exec(auth.credentials);
+
+  if (!match) {
+    return callback(new restify.InvalidHeaderError("Your Authorization header does not include an 'apikey' value."));
+  }
+
+  callback(null, match[1]);
+};
+
+/**
+ * @description Access the name associated with an API key. If the key is not valid, emit an
+ *   error instead.
+ */
+var validate_apikey = function (key, callback) {
+  // Always accept the admin's API key.
+  if (key === config.admin_apikey()) {
+    return callback(null, "administrator");
+  }
+
+  callback(new restify.UnauthorizedError("The API key you provided is invalid."));
+};
+
+/**
+ * @description Require an API key on the request. Return a 401 response if no key is present.
+ */
+exports.requireKey = [
+  restify.authorizationParser(),
+    function (req, res, next) {
+    async.waterfall([
+      async.apply(parse_auth, req.authorization),
+      validate_apikey
+    ], function (err, name) {
+      next.ifError(err);
+
+      log.debug("Authenticated as [" + name + "]");
+      next();
+    });
+  }
+];

--- a/src/auth.js
+++ b/src/auth.js
@@ -38,10 +38,9 @@ var parse_auth = function (auth, callback) {
  *   recognized, or if admin_only is true but the key is not an admin key.
  */
 var locate_keyname = function (admin_only, key, callback) {
-
   // Always accept the admin's API key.
   if (key === config.admin_apikey()) {
-    return callback(null, "administrator");
+    return callback(null, { key: key, name: "administrator"});
   }
 
   if (admin_only) {
@@ -60,7 +59,7 @@ var locate_keyname = function (admin_only, key, callback) {
       log.error("Expected one API key document, but got " + docs.length + ".", docs);
     }
 
-    callback(null, docs[0].name);
+    callback(null, { key: key, name: docs[0].name});
   });
 };
 
@@ -74,11 +73,12 @@ var create_apikey_handler = function (admin_only) {
     async.waterfall([
       async.apply(parse_auth, req.authorization),
       async.apply(locate_keyname, admin_only)
-    ], function (err, name) {
+    ], function (err, result) {
       next.ifError(err);
 
-      log.debug("Request authenticated as [" + name + "]");
-      req.apikey_name = name;
+      log.debug("Request authenticated as [" + result.name + "]");
+      req.apikey = result.key;
+      req.apikey_name = result.name;
       next();
     });
   };

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,7 @@ var configuration = {
   rackspace_apikey: null,
   rackspace_region: null,
   content_container: null,
+  admin_apikey: null,
   asset_container: null,
   mongodb_url: null,
   content_log_level: "info"

--- a/src/config.js
+++ b/src/config.js
@@ -9,8 +9,8 @@ var configuration = {
   rackspace_username: null,
   rackspace_apikey: null,
   rackspace_region: null,
-  content_container: null,
   admin_apikey: null,
+  content_container: null,
   asset_container: null,
   mongodb_url: null,
   content_log_level: "info"

--- a/src/content.js
+++ b/src/content.js
@@ -82,7 +82,6 @@ exports.retrieve = function (req, res, next) {
       return;
     }
 
-    res.status(200);
     res.json(doc);
     next();
   });
@@ -100,7 +99,6 @@ exports.store = function (req, res, next) {
   });
 
   dest.on('success', function () {
-    res.status(200);
     res.send();
     next();
   });
@@ -120,12 +118,10 @@ exports.delete = function (req, res, next) {
     if (err) {
       res.status(err.statusCode);
       res.send();
-      next();
-      return;
+      return next();
     }
 
-    res.status(200);
-    res.send();
+    res.send(204);
     next();
   });
 };

--- a/src/keys.js
+++ b/src/keys.js
@@ -1,0 +1,27 @@
+// Issue and revoke API keys.
+
+var
+  async = require('async'),
+  config = require('./config'),
+  connection = require('./connection'),
+  logging = require('./logging');
+
+var log = logging.getLogger(config.content_log_level());
+
+exports.issue = function(req, res, next) {
+  log.info("Issuing an API key for [" + req.query.named + "]");
+
+  res.status(200);
+  res.send();
+
+  next();
+};
+
+exports.revoke = function(req, res, next) {
+  log.info("Revoking an API key");
+
+  res.status(200);
+  res.send();
+
+  next();
+};

--- a/src/keys.js
+++ b/src/keys.js
@@ -13,7 +13,7 @@ var log = logging.getLogger(config.content_log_level());
  * @description Generate a fresh API key.
  */
 function generate_key(callback) {
-  crypto.randomBytes(1024, function (err, buf) {
+  crypto.randomBytes(128, function (err, buf) {
     if (err) return callback(err);
 
     callback(null, { apikey: buf.toString('hex')});

--- a/src/keys.js
+++ b/src/keys.js
@@ -1,6 +1,7 @@
 // Issue and revoke API keys.
 
 var
+  crypto = require('crypto'),
   async = require('async'),
   config = require('./config'),
   connection = require('./connection'),
@@ -8,13 +9,60 @@ var
 
 var log = logging.getLogger(config.content_log_level());
 
+/**
+ * @description Generate a fresh API key.
+ */
+function generate_key(callback) {
+  crypto.randomBytes(1024, function (err, buf) {
+    if (err) return callback(err);
+
+    callback(null, { apikey: buf.toString('hex')});
+  });
+}
+
+/**
+ * @description Store an API key in Mongo.
+ */
+function store_key(name, result, callback) {
+  var doc = { name: name, apikey: result.apikey };
+
+  connection.db.collection("api_keys").insertOne(doc, function (err) {
+    if (err) return callback(err);
+
+    callback(null, { apikey: result.apikey });
+  });
+}
+
 exports.issue = function(req, res, next) {
-  log.info("Issuing an API key for [" + req.query.named + "]");
+  var name = req.query.named;
 
-  res.status(200);
-  res.send();
+  if (!name) {
+    log.warn("Attempt to issue an API key without a name.");
 
-  next();
+    res.status(400);
+    res.json({ error: "You must specify a name for the API key" });
+
+    next();
+  }
+
+  log.info("Issuing an API key for [" + name + "]");
+
+  async.waterfall([
+    generate_key,
+    async.apply(store_key, name)
+  ], function (err, result) {
+    if (err) {
+      log.error("Unable to issue an API key.", err);
+
+      res.status(500);
+      res.json({ error: "Unable to issue an API key!" });
+      next();
+    }
+
+    res.status(200);
+    res.json({ apikey: result.apikey });
+    next();
+  });
 };
 
 exports.revoke = function(req, res, next) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -15,7 +15,11 @@ exports.loadRoutes = function (server) {
   server.put('/content/:id', auth.require_key, content.store);
   server.del('/content/:id', auth.require_key, content.delete);
 
-  server.post('/assets', restify.bodyParser(), restify.queryParser(), assets.accept);
+  server.post('/assets',
+    auth.require_key,
+    restify.bodyParser(),
+    restify.queryParser(),
+    assets.accept);
 
   server.post('/keys', auth.require_admin, restify.queryParser(), keys.issue);
   server.del('/keys/:key', auth.require_admin, keys.revoke);

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,7 +4,8 @@ var restify = require('restify');
 var
   version = require('./version'),
   content = require('./content'),
-  assets = require('./assets');
+  assets = require('./assets'),
+  keys = require('./keys');
 
 exports.loadRoutes = function (server) {
   server.get('/version', version.report);
@@ -14,4 +15,7 @@ exports.loadRoutes = function (server) {
   server.del('/content/:id', content.delete);
 
   server.post('/assets', restify.bodyParser(), restify.queryParser(), assets.accept);
+
+  server.post('/keys', restify.queryParser(), keys.issue);
+  server.del('/keys/:key', keys.revoke);
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -12,8 +12,8 @@ exports.loadRoutes = function (server) {
   server.get('/version', version.report);
 
   server.get('/content/:id', content.retrieve);
-  server.put('/content/:id', content.store);
-  server.del('/content/:id', content.delete);
+  server.put('/content/:id', auth.require_key, content.store);
+  server.del('/content/:id', auth.require_key, content.delete);
 
   server.post('/assets', restify.bodyParser(), restify.queryParser(), assets.accept);
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,6 +2,7 @@ var restify = require('restify');
 
 // Handlers
 var
+  auth = require('./auth'),
   version = require('./version'),
   content = require('./content'),
   assets = require('./assets'),
@@ -16,6 +17,6 @@ exports.loadRoutes = function (server) {
 
   server.post('/assets', restify.bodyParser(), restify.queryParser(), assets.accept);
 
-  server.post('/keys', restify.queryParser(), keys.issue);
-  server.del('/keys/:key', keys.revoke);
+  server.post('/keys', auth.requireKey, restify.queryParser(), keys.issue);
+  server.del('/keys/:key', auth.requireKey, keys.revoke);
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -17,6 +17,6 @@ exports.loadRoutes = function (server) {
 
   server.post('/assets', restify.bodyParser(), restify.queryParser(), assets.accept);
 
-  server.post('/keys', auth.requireKey, restify.queryParser(), keys.issue);
-  server.del('/keys/:key', auth.requireKey, keys.revoke);
+  server.post('/keys', auth.require_admin, restify.queryParser(), keys.issue);
+  server.del('/keys/:key', auth.require_admin, keys.revoke);
 };

--- a/test/assets.js
+++ b/test/assets.js
@@ -7,6 +7,7 @@ var
   request = require("supertest"),
   connection = require("../src/connection"),
   connmocks = require("./mock/connection"),
+  authhelper = require("./helpers/auth"),
   server = require("../src/server");
 
 describe("/assets", function() {
@@ -14,6 +15,7 @@ describe("/assets", function() {
 
   beforeEach(function () {
     mocks = connmocks.install(connection);
+    authhelper.install();
   });
 
   it("accepts an asset file and produces a fingerprinted filename", function(done) {
@@ -24,9 +26,19 @@ describe("/assets", function() {
 
     request(server.create())
       .post("/assets")
+      .set("Authorization", authhelper.AUTH_USER)
       .attach("first", "test/fixtures/asset-file.txt")
       .expect(200)
       .expect("Content-Type", /json/)
       .expect({ "asset-file.txt": final_name }, done);
   });
+
+  it("requires authentication", function(done) {
+    authhelper.ensureAuthIsRequired(
+      request(server.create())
+        .post("/assets")
+        .attach("first", "test/fixtures/asset-file.txt"),
+      done);
+  });
+
 });

--- a/test/config.js
+++ b/test/config.js
@@ -12,6 +12,7 @@ describe("config", function () {
       RACKSPACE_USERNAME: "me",
       RACKSPACE_APIKEY: "12345",
       RACKSPACE_REGION: "space",
+      ADMIN_APIKEY: "12345",
       CONTENT_CONTAINER: "the-content-container",
       ASSET_CONTAINER: "the-asset-container",
       MONGODB_URL: "mongodb-url",
@@ -21,6 +22,7 @@ describe("config", function () {
     expect(config.rackspace_username()).to.equal("me");
     expect(config.rackspace_apikey()).to.equal("12345");
     expect(config.rackspace_region()).to.equal("space");
+    expect(config.admin_apikey()).to.equal("12345");
     expect(config.content_container()).to.equal("the-content-container");
     expect(config.asset_container()).to.equal("the-asset-container");
     expect(config.mongodb_url()).to.equal("mongodb-url");

--- a/test/content.js
+++ b/test/content.js
@@ -3,7 +3,6 @@
  */
 
 var
-  restify = require("restify"),
   request = require("supertest"),
   expect = require("chai").expect,
   connection = require("../src/connection"),

--- a/test/content.js
+++ b/test/content.js
@@ -74,7 +74,7 @@ describe("/content", function () {
       request(server.create())
         .delete("/content/foo%26bar")
         .set("Authorization", authhelper.AUTH_USER)
-        .expect(200)
+        .expect(204)
         .end(function (err, res) {
           if (err) return done(err);
 

--- a/test/content.js
+++ b/test/content.js
@@ -7,6 +7,7 @@ var
   expect = require("chai").expect,
   connection = require("../src/connection"),
   connmocks = require("./mock/connection"),
+  authhelper = require("./helpers/auth"),
   server = require("../src/server");
 
 describe("/content", function () {
@@ -14,6 +15,7 @@ describe("/content", function () {
 
   beforeEach(function () {
     mocks = connmocks.install(connection);
+    authhelper.install();
   });
 
   describe("#store", function () {
@@ -21,6 +23,7 @@ describe("/content", function () {
     it("persists new content into Cloud Files", function (done) {
       request(server.create())
         .put("/content/foo%26bar")
+        .set("Authorization", authhelper.AUTH_USER)
         .set("Content-Type", "application/json")
         .set("Accept", "application/json")
         .send('{ "something": "body" }')
@@ -34,6 +37,14 @@ describe("/content", function () {
 
           done();
         });
+    });
+
+    it("requires authentication", function (done) {
+      authhelper.ensureAuthIsRequired(
+        request(server.create())
+          .put("/content/something")
+          .send({ thing: "stuff" }),
+        done);
     });
 
   });
@@ -62,6 +73,7 @@ describe("/content", function () {
 
       request(server.create())
         .delete("/content/foo%26bar")
+        .set("Authorization", authhelper.AUTH_USER)
         .expect(200)
         .end(function (err, res) {
           if (err) return done(err);
@@ -72,6 +84,13 @@ describe("/content", function () {
 
           done();
         });
+    });
+
+    it("requires authentication", function (done) {
+      authhelper.ensureAuthIsRequired(
+        request(server.create())
+          .delete("/content/foo%26bar"),
+        done);
     });
 
   });

--- a/test/helpers/auth.js
+++ b/test/helpers/auth.js
@@ -6,7 +6,11 @@ var
 
 exports.APIKEY_ADMIN = "12345";
 
+exports.AUTH_ADMIN = 'deconst apikey="' + exports.APIKEY_ADMIN + '"';
+
 exports.APIKEY_USER = "54321";
+
+exports.AUTH_USER = 'deconst apikey="' + exports.APIKEY_USER + '"';
 
 /**
  * @description Populate the DB mock and the application environment to recognize the fixture
@@ -44,7 +48,7 @@ exports.ensureAuthIsRequired = function (action, done) {
  */
 exports.ensureAdminIsRequired = function (action, done) {
   action
-    .set("Authorization", 'deconst apikey="' + exports.APIKEY_USER + '"')
+    .set("Authorization", exports.AUTH_USER)
     .expect(401)
     .expect("Content-Type", "application/json")
     .expect({ code: "UnauthorizedError", message: "Only admins may access this endpoint." }, done);

--- a/test/helpers/auth.js
+++ b/test/helpers/auth.js
@@ -1,0 +1,51 @@
+// Helper functions used to test endpoints that are protected by authentication.
+
+var
+  config = require("../../src/config"),
+  connection = require("../../src/connection");
+
+exports.APIKEY_ADMIN = "12345";
+
+exports.APIKEY_USER = "54321";
+
+/**
+ * @description Populate the DB mock and the application environment to recognize the fixture
+ *   API keys.
+ */
+exports.install = function () {
+  config.configure({
+    RACKSPACE_USERNAME: "me",
+    RACKSPACE_APIKEY: "11111",
+    RACKSPACE_REGION: "space",
+    ADMIN_APIKEY: exports.APIKEY_ADMIN,
+    CONTENT_CONTAINER: "the-content-container",
+    ASSET_CONTAINER: "the-asset-container",
+    MONGODB_URL: "mongodb-url",
+    CONTENT_LOG_LEVEL: "debug"
+  });
+
+  var doc = { name: "user", apikey: exports.APIKEY_USER };
+
+  connection.db.collection("api_keys").insertOne(doc);
+};
+
+/**
+ * @description Test helper to ensure that a route fails if no API key is given.
+ */
+exports.ensureAuthIsRequired = function (action, done) {
+  action
+    .expect(401)
+    .expect("Content-Type", "application/json")
+    .expect({ code: "UnauthorizedError", message: "An API key is required for this endpoint." }, done);
+};
+
+/**
+ * @description Test helper to ensure that a route fails if a non-admin API key is given.
+ */
+exports.ensureAdminIsRequired = function (action, done) {
+  action
+    .set("Authorization", 'deconst apikey="' + exports.APIKEY_USER + '"')
+    .expect(401)
+    .expect("Content-Type", "application/json")
+    .expect({ code: "UnauthorizedError", message: "Only admins may access this endpoint." }, done);
+};

--- a/test/keys.js
+++ b/test/keys.js
@@ -59,7 +59,11 @@ describe("/keys", function () {
         done);
     });
 
-    it("prevents non-admins from issuing keys");
+    it("prevents non-admins from issuing keys", function (done) {
+      authhelper.ensureAdminIsRequired(
+        request(server.create()).post("/keys?named=mine"),
+        done);
+    });
   });
 
   describe("DELETE", function () {
@@ -69,7 +73,7 @@ describe("/keys", function () {
 
       request(server.create())
         .delete("/keys/54321")
-        .set("Authorization", 'deconst apikey="12345"')
+        .set("Authorization", authhelper.AUTH_ADMIN)
         .expect(204)
         .expect(function () {
           var

--- a/test/keys.js
+++ b/test/keys.js
@@ -10,6 +10,16 @@ var
   config = require("../src/config"),
   server = require("../src/server");
 
+/*
+ * Test helper to ensure that a route fails if no valid API key is given.
+ */
+var ensureAuthIsRequired = function (action, done) {
+  action
+    .expect(401)
+    .expect("Content-Type", "application/json")
+    .expect({ code: "UnauthorizedError", message: "An API key is required for this endpoint." }, done);
+};
+
 describe("/keys", function () {
   var mocks;
 
@@ -62,7 +72,11 @@ describe("/keys", function () {
         .expect(400, done);
     });
 
-    it("requires authentication");
+    it("requires authentication", function (done) {
+      ensureAuthIsRequired(
+        request(server.create()).post("/keys?named=mine"),
+        done);
+    });
 
     it("prevents non-admins from issuing keys");
   });

--- a/test/keys.js
+++ b/test/keys.js
@@ -1,0 +1,24 @@
+/*
+ * Unit tests for API key management.
+ */
+
+var
+  request = require("supertest"),
+  expect = require("chai").expect,
+  config = require("../src/config"),
+  server = require("../src/server");
+
+describe("/key", function () {
+  describe("POST", function () {
+    it("requires authentication");
+    it("allows an admin to issue a new key");
+    it("prevents non-admins from issuing keys");
+  });
+
+  describe("DELETE", function () {
+    it("requires authentication");
+    it("allows an admin to revoke an existing key");
+    it("prevents non-admins from revoking keys");
+    it("doesn't allow admins to revoke their own key");
+  });
+});

--- a/test/keys.js
+++ b/test/keys.js
@@ -7,35 +7,16 @@ var
   expect = require("chai").expect,
   connection = require("../src/connection"),
   connmocks = require("./mock/connection"),
+  authhelper = require("./helpers/auth"),
   config = require("../src/config"),
   server = require("../src/server");
-
-/*
- * Test helper to ensure that a route fails if no valid API key is given.
- */
-var ensureAuthIsRequired = function (action, done) {
-  action
-    .expect(401)
-    .expect("Content-Type", "application/json")
-    .expect({ code: "UnauthorizedError", message: "An API key is required for this endpoint." }, done);
-};
 
 describe("/keys", function () {
   var mocks;
 
   beforeEach(function () {
-    config.configure({
-      RACKSPACE_USERNAME: "me",
-      RACKSPACE_APIKEY: "12345",
-      RACKSPACE_REGION: "space",
-      ADMIN_APIKEY: "12345",
-      CONTENT_CONTAINER: "the-content-container",
-      ASSET_CONTAINER: "the-asset-container",
-      MONGODB_URL: "mongodb-url",
-      CONTENT_LOG_LEVEL: "debug"
-    });
-
     mocks = connmocks.install(connection);
+    authhelper.install();
   });
 
   describe("POST", function () {
@@ -73,7 +54,7 @@ describe("/keys", function () {
     });
 
     it("requires authentication", function (done) {
-      ensureAuthIsRequired(
+      authhelper.ensureAuthIsRequired(
         request(server.create()).post("/keys?named=mine"),
         done);
     });

--- a/test/keys.js
+++ b/test/keys.js
@@ -50,7 +50,11 @@ describe("/keys", function () {
       request(server.create())
         .post("/keys")
         .set("Authorization", 'deconst apikey="12345"')
-        .expect(400, done);
+        .expect(409)
+        .expect({
+          code: "MissingParameter",
+          message: "You must specify a name for the API key"
+        }, done);
     });
 
     it("requires authentication", function (done) {
@@ -103,6 +107,13 @@ describe("/keys", function () {
         done);
     });
 
-    it("doesn't allow admins to revoke their own key");
+    it("doesn't allow admins to revoke their own key", function (done) {
+      request(server.create())
+        .delete("/keys/" + authhelper.APIKEY_ADMIN)
+        .set("Authorization", authhelper.AUTH_ADMIN)
+        .expect(409)
+        .expect("Content-Type", "application/json")
+        .expect({ code: "InvalidArgument", message: "You cannot revoke your own API key." }, done);
+    });
   });
 });

--- a/test/keys.js
+++ b/test/keys.js
@@ -5,13 +5,44 @@
 var
   request = require("supertest"),
   expect = require("chai").expect,
+  connection = require("../src/connection"),
+  connmocks = require("./mock/connection"),
   config = require("../src/config"),
   server = require("../src/server");
 
-describe("/key", function () {
+describe("/keys", function () {
+  var mocks;
+
+  beforeEach(function () {
+    config.configure({
+      RACKSPACE_USERNAME: "me",
+      RACKSPACE_APIKEY: "12345",
+      RACKSPACE_REGION: "space",
+      ADMIN_APIKEY: "12345",
+      CONTENT_CONTAINER: "the-content-container",
+      ASSET_CONTAINER: "the-asset-container",
+      MONGODB_URL: "mongodb-url",
+      CONTENT_LOG_LEVEL: "debug"
+    });
+
+    mocks = connmocks.install(connection);
+  });
+
   describe("POST", function () {
     it("requires authentication");
-    it("allows an admin to issue a new key");
+
+    it("allows an admin to issue a new key", function (done) {
+      request(server.create())
+        .post("/keys?named=someone")
+        .set("Authorization", 'deconst apikey="12345"')
+        .expect(200)
+        .expect("Content-Type", "application/json")
+        .expect(function (res) {
+          if (!("apikey" in res.body)) throw new Error("No API key issued");
+        })
+        .end(done);
+    });
+
     it("prevents non-admins from issuing keys");
   });
 

--- a/test/keys.js
+++ b/test/keys.js
@@ -91,8 +91,18 @@ describe("/keys", function () {
         .end(done);
     });
 
-    it("requires authentication");
-    it("prevents non-admins from revoking keys");
+    it("requires authentication", function (done) {
+      authhelper.ensureAuthIsRequired(
+        request(server.create()).delete("/keys/54321"),
+        done);
+    });
+
+    it("prevents non-admins from revoking keys", function (done) {
+      authhelper.ensureAdminIsRequired(
+        request(server.create()).delete("/keys/54321"),
+        done);
+    });
+
     it("doesn't allow admins to revoke their own key");
   });
 });

--- a/test/keys.js
+++ b/test/keys.js
@@ -68,8 +68,31 @@ describe("/keys", function () {
   });
 
   describe("DELETE", function () {
+
+    it("allows an admin to revoke an existing key", function (done) {
+      mocks.mock_db.collection("api_keys").insertOne({ name: "torevoke", apikey: "54321" });
+
+      request(server.create())
+        .delete("/keys/54321")
+        .set("Authorization", 'deconst apikey="12345"')
+        .expect(204)
+        .expect(function () {
+          var
+            found = false,
+            issued = mocks.mock_db.collection("api_keys").find().toArray();
+
+          issued.forEach(function (each) {
+            if (each.apikey === "54321" && each.name === "torevoke") {
+              found = true;
+            }
+          });
+
+          if (found) throw new Error("Revoked API key is still present in the database");
+        })
+        .end(done);
+    });
+
     it("requires authentication");
-    it("allows an admin to revoke an existing key");
     it("prevents non-admins from revoking keys");
     it("doesn't allow admins to revoke their own key");
   });

--- a/test/mock/connection.js
+++ b/test/mock/connection.js
@@ -68,7 +68,15 @@ exports.install = function (connection) {
     add_collection: function (name, contents) {
       var collection = {
         find: function () { return collection; },
-        toArray: function (callback) { callback(null, contents); }
+        insertOne: function (doc, callback) {
+          contents.push(doc);
+
+          callback(null, mock_db);
+        },
+        toArray: function (callback) {
+          if (callback) callback(null, contents);
+          return contents;
+        }
       };
       this.collections[name] = collection;
     },

--- a/test/mock/connection.js
+++ b/test/mock/connection.js
@@ -71,7 +71,21 @@ exports.install = function (connection) {
         insertOne: function (doc, callback) {
           contents.push(doc);
 
-          callback(null, mock_db);
+          if (callback) callback(null, mock_db);
+        },
+        deleteOne: function (filter, callback) {
+          var resultIndex = -1;
+          contents.forEach(function (each, index) {
+            if (filter.apikey === each.apikey) {
+              resultIndex = index;
+            }
+          });
+
+          if (resultIndex !== -1) {
+            contents.splice(resultIndex, 1);
+          }
+
+          if (callback) callback(null);
         },
         toArray: function (callback) {
           if (callback) callback(null, contents);


### PR DESCRIPTION
Protect requests that manipulate content by requiring an API key.
- [x] Accept an admin key from the process' environment.
- [x] Introduce a `/keys` endpoint to issue and revoke API keys.
- [x] Create restify middleware to assert that the current request has a valid API key and respond appropriately otherwise.
- [x] Create middleware to assert that the current request has an admin key.
- [x] Require a valid key to store or delete metadata envelopes.
- [x] Document the new endpoints and behavior in the README.

The foundation for deconst/deconst-docs#15.
