### PR TITLE
Perform queries for related envelopes in outgoing documents.

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -78,7 +78,7 @@ function handleQueries(doc, callback) {
     queries.push(doc.envelope.queries[queryNames[i]]);
   }
 
-  delete doc.queries;
+  delete doc.envelope.queries;
 
   log.debug("Processing " + queries.length + " envelope queries.");
 

--- a/src/content.js
+++ b/src/content.js
@@ -85,7 +85,25 @@ function handleQueries(doc, callback) {
   async.map(
     queries,
     function (query, callback) {
-      connection.db.collection("envelopes").find(query).toArray(callback);
+      var
+        order = query.$order || { publish_date: -1 },
+        skip = query.$skip,
+        limit = query.$limit;
+
+      if (query.$query) {
+        query = query.$query;
+        delete query.$query;
+      }
+      delete query.$skip;
+      delete query.$limit;
+
+      var cursor = connection.db.collection("envelopes").find(query);
+
+      cursor.sort(order);
+      if (skip) { cursor.skip(skip); }
+      if (limit) { cursor.limit(limit); }
+
+      cursor.toArray(callback);
     },
     function (err, results) {
       if (err) return callback(err);

--- a/test/content.js
+++ b/test/content.js
@@ -97,6 +97,45 @@ describe("/content", function () {
         }, done);
     });
 
+    it("collects related documents when a 'queries' attribute is present", function (done) {
+      mocks.mockClient.content.hasqueries = JSON.stringify({
+        queries: {
+          somename: { category: "sample" },
+          anothername: { tag: "important" }
+        },
+        body: ".."
+      });
+
+      mocks.mockDB.addCollection("envelopes", [
+        { categories: ["sample", "other"], title: "zero", content_id: "id0" },
+        { categories: ["sample", "blerp"], title: "one", content_id: "id1" },
+        { categories: ["nope", "none"], tags: ["uhuh"], title: "two", content_id: "id2" },
+        { tags: ["important"], title: "three", content_id: "id3" },
+        { tags: ["important", "extra"], title: "four", content_id: "id4" }
+      ]);
+
+      request(server.create())
+        .get("/content/hasqueries")
+        .expect("Content-Type", "application/json")
+        .expect(200)
+        .expect({
+          assets: {},
+          envelope: {
+            body: ".."
+          },
+          results: {
+            somename: [
+              { categories: ["sample", "other"], title: "zero", content_id: "id0" },
+              { categories: ["sample", "blerp"], title: "one", content_id: "id1" }
+            ],
+            anothername: [
+              { tags: ["important"], title: "three", content_id: "id3" },
+              { tags: ["important", "extra"], title: "four", content_id: "id4" }
+            ]
+          }
+        }, done);
+    });
+
   });
 
   describe("#delete", function () {

--- a/test/mock/client.js
+++ b/test/mock/client.js
@@ -1,0 +1,54 @@
+// Mock pkgcloud functionality.
+
+var
+  util = require("util"),
+  stream = require("stream"),
+  Writable = stream.Writable,
+  Readable = stream.Readable;
+
+util.inherits(Sink, Writable);
+
+function Sink(options) {
+  Writable.call(this, options);
+  var self = this;
+
+  this._write = function (chunk, enc, next) {
+    next();
+  };
+
+  this.on("finish", function () {
+    self.emit("success");
+  });
+}
+
+exports.create = function() {
+  return {
+    // Internal state, exposed for expectation-writing convenience.
+
+    uploaded: [],
+    downloaded: [],
+    deleted: [],
+    content: {},
+
+    // Mocked pkgcloud client API.
+
+    upload: function (params) {
+      this.uploaded.push(params);
+      return new Sink();
+    },
+
+    download: function (params) {
+      this.downloaded.push(params);
+      var rs = new Readable();
+      rs.push(this.content[params.remote]);
+      rs.push(null);
+      return rs;
+    },
+
+    removeFile: function (container, name, callback) {
+      this.deleted.push(name);
+      delete this.content[name];
+      callback(null);
+    }
+  };
+};

--- a/test/mock/connection.js
+++ b/test/mock/connection.js
@@ -3,55 +3,12 @@
  */
 
 var
-  util = require("util"),
-  stream = require("stream"),
-  Writable = stream.Writable,
-  Readable = stream.Readable;
-
-util.inherits(Sink, Writable);
-
-function Sink(options) {
-  Writable.call(this, options);
-  var self = this;
-
-  this._write = function (chunk, enc, next) {
-    next();
-  };
-
-  this.on("finish", function () {
-    self.emit("success");
-  });
-}
+  mockClient = require("./client"),
+  mockDatabase = require("./database");
 
 exports.install = function (connection) {
   // Mock Rackspace Cloud Files client.
-  var mockClient = {
-    uploaded: [],
-    downloaded: [],
-    deleted: [],
-    content: {},
-
-    upload: function (params) {
-      this.uploaded.push(params);
-      return new Sink();
-    },
-
-    download: function (params) {
-      this.downloaded.push(params);
-      var rs = new Readable();
-      rs.push(this.content[params.remote]);
-      rs.push(null);
-      return rs;
-    },
-
-    removeFile: function (container, name, callback) {
-      this.deleted.push(name);
-      delete this.content[name];
-      callback(null);
-    }
-  };
-
-  connection.client = mockClient;
+  connection.client = mockClient.create();
 
   connection.contentContainer = {
     name: "the_content_container"
@@ -62,51 +19,10 @@ exports.install = function (connection) {
     cdnSslUri: "https://example.com/fake/cdn/url"
   };
 
-  var mockDB = {
-    collections: {},
-
-    addCollection: function (name, contents) {
-      var collection = {
-        find: function () { return collection; },
-        insertOne: function (doc, callback) {
-          contents.push(doc);
-
-          if (callback) callback(null, mockDB);
-        },
-        deleteOne: function (filter, callback) {
-          var resultIndex = -1;
-          contents.forEach(function (each, index) {
-            if (filter.apikey === each.apikey) {
-              resultIndex = index;
-            }
-          });
-
-          if (resultIndex !== -1) {
-            contents.splice(resultIndex, 1);
-          }
-
-          if (callback) callback(null);
-        },
-        toArray: function (callback) {
-          if (callback) callback(null, contents);
-          return contents;
-        }
-      };
-      this.collections[name] = collection;
-    },
-
-    collection: function (name) {
-      if (!this.collections[name]) {
-        this.addCollection(name, []);
-      }
-      return this.collections[name];
-    }
-  };
-
-  connection.db = mockDB;
+  connection.db = mockDatabase.create();
 
   return {
-    mockClient: mockClient,
-    mockDB: mockDB
+    mockClient: connection.client,
+    mockDB: connection.db
   };
 };

--- a/test/mock/database.js
+++ b/test/mock/database.js
@@ -1,0 +1,58 @@
+// Mock basic MongoDB functionality.
+
+var createResultSet = function (results) {
+  return {
+    toArray: function (callback) {
+      if (callback) callback(null, results);
+      return results;
+    }
+  };
+};
+
+var createMockCollection = function (db, contents) {
+  return {
+    find: function () { return createResultSet(contents); },
+    insertOne: function (doc, callback) {
+      contents.push(doc);
+
+      if (callback) callback(null, db);
+    },
+    deleteOne: function (filter, callback) {
+      var resultIndex = -1;
+      contents.forEach(function (each, index) {
+        if (filter.apikey === each.apikey) {
+          resultIndex = index;
+        }
+      });
+
+      if (resultIndex !== -1) {
+        contents.splice(resultIndex, 1);
+      }
+
+      if (callback) callback(null);
+    }
+  };
+};
+
+exports.create = function () {
+  return {
+    // Internal state, exposed for expectation-writing convenience.
+
+    collections: {},
+
+    // Mocked MongoDB client API.
+
+    collection: function (name) {
+      if (!this.collections[name]) {
+        this.addCollection(name, []);
+      }
+      return this.collections[name];
+    },
+
+    // Convenience methods for tests themselves.
+
+    addCollection: function (name, contents) {
+      this.collections[name] = createMockCollection(this, contents);
+    }
+  };
+};

--- a/test/mock/database.js
+++ b/test/mock/database.js
@@ -4,6 +4,10 @@ var _ = require('lodash');
 
 var createResultSet = function (results) {
   return {
+    sort: function (attr) {
+      return this;
+    },
+
     toArray: function (callback) {
       if (callback) callback(null, results);
       return results;


### PR DESCRIPTION
When a `queries` attribute is present in a retrieved metadata envelope:
- Remove it from the envelope;
- Use each query value to query the "envelopes" collection in MongoDB;
- Attach the results to the outgoing content document in a `results` attribute, named identically to the query attribute.

This is the next phase of deconst/deconst-docs#41.
#### Remaining Work
- [ ] Order the collected results.
- [ ] Support pagination.
