### PR TITLE
Store publish dates of indexed envelopes as timestamps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/content.js
+++ b/src/content.js
@@ -87,6 +87,17 @@ function handleQueries(doc, callback) {
 
     doc.results = {};
     for (var i = 0; i < results.length; i++) {
+      for (var j = 0; j < results.length; j++) {
+        var each = results[i][j];
+
+        if (each.publish_date) {
+          console.log(each.publish_date);
+          var d = new Date();
+          d.setTime(each.publish_date);
+          each.publish_date = d.toUTCString();
+        }
+      }
+
       doc.results[queryNames[i]] = results[i];
     }
 
@@ -115,14 +126,6 @@ function handleQuery(query, callback) {
   cursor.sort(order);
   if (skip) { cursor.skip(skip); }
   if (limit) { cursor.limit(limit); }
-
-  cursor.map(function (original) {
-    if (original.publish_date) {
-      original.publish_date = original.publish_date.toUTCString();
-    }
-
-    return original;
-  });
 
   cursor.toArray(callback);
 }

--- a/test/content.js
+++ b/test/content.js
@@ -71,7 +71,7 @@ describe("/content", function () {
           expect(contents).to.deep.include({
             contentID: "tagged",
             title: "title goes here",
-            publish_date: "Tue, 05 Aug 2014 23:59:00 -0400",
+            publish_date: Date.parse("Tue, 05 Aug 2014 23:59:00 -0400"),
             tags: ["tag1", "tag2"],
             categories: ["cat1", "cat2"]
           });

--- a/test/mock/database.js
+++ b/test/mock/database.js
@@ -13,11 +13,6 @@ var createResultSet = function (results) {
     toArray: function (callback) {
       if (callback) callback(null, contents);
       return contents;
-    },
-
-    map: function (transform) {
-      contents = contents.map(transform);
-      return null;
     }
   };
 };

--- a/test/mock/database.js
+++ b/test/mock/database.js
@@ -3,14 +3,21 @@
 var _ = require('lodash');
 
 var createResultSet = function (results) {
+  var contents = results;
+
   return {
     sort: function (attr) {
       return this;
     },
 
     toArray: function (callback) {
-      if (callback) callback(null, results);
-      return results;
+      if (callback) callback(null, contents);
+      return contents;
+    },
+
+    map: function (transform) {
+      contents = contents.map(transform);
+      return null;
     }
   };
 };


### PR DESCRIPTION
Transform the `publish_date` attribute of each indexed document into a Unix timestamp before storage. Transform it back to a date string in RFC 2822 format at result collection time.
