### PR TITLE
Asset proxy

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -227,3 +227,39 @@ exports.list = function (req, res, next) {
     next();
   });
 };
+
+exports.retrieve = function (req, res, next) {
+  log.debug({
+    action: 'assetretrieve',
+    message: 'Asset requested directly.'
+  });
+
+  var reqStart = Date.now();
+
+  storage.getAsset(req.params.id, function (err, asset) {
+    if (err) {
+      log.error({
+        action: 'assetretrieve',
+        statusCode: err.statusCode || 500,
+        message: 'Unable to retrieve asset',
+        error: err.message,
+        stack: err.stack
+      });
+      return next(err);
+    }
+
+    res.header('Content-Type', asset.contentType);
+    res.send(asset.body);
+
+    log.info({
+      action: 'contentretrieve',
+      statusCode: 200,
+      assetFilename: req.params.id,
+      assetContentType: asset.contentType,
+      totalReqDuration: Date.now() - reqStart,
+      message: 'Asset request successful.'
+    });
+
+    next();
+  });
+}

--- a/src/assets.js
+++ b/src/assets.js
@@ -262,4 +262,4 @@ exports.retrieve = function (req, res, next) {
 
     next();
   });
-}
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -21,6 +21,7 @@ exports.loadRoutes = function (server) {
     assets.accept);
 
   server.get('/assets', assets.list);
+  server.get('/assets/:id', assets.retrieve);
 
   server.post('/keys', auth.requireAdmin, restify.queryParser(), keys.issue);
   server.del('/keys/:key', auth.requireAdmin, keys.revoke);

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -14,6 +14,7 @@ var delegates = [
   'storeAsset',
   'nameAsset',
   'findNamedAssets',
+  'getAsset',
   'storeKey',
   'deleteKey',
   'findKeys',

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -69,7 +69,7 @@ MemoryStorage.prototype.getAsset = function (filename, callback) {
   }
 
   callback(null, asset);
-}
+};
 
 MemoryStorage.prototype.storeKey = function (key, callback) {
   this.keys[key.apikey] = key.name;

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -56,6 +56,21 @@ MemoryStorage.prototype.findNamedAssets = function (callback) {
   callback(null, _.values(this.namedAssets));
 };
 
+MemoryStorage.prototype.getAsset = function (filename, callback) {
+  var asset = this.assets[filename];
+
+  if (asset === undefined) {
+    var err = new Error('Memory storage error');
+
+    err.statusCode = 404;
+    err.responseBody = 'Oh snap';
+
+    return callback(err);
+  }
+
+  callback(null, asset);
+}
+
 MemoryStorage.prototype.storeKey = function (key, callback) {
   this.keys[key.apikey] = key.name;
   callback();

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -89,6 +89,42 @@ RemoteStorage.prototype.findNamedAssets = function (callback) {
 };
 
 /**
+ * @description Retrieve an asset directly through the content service API. This is useless for
+ *  remote storage (because you can and should use the CDN url instead) but implemented for
+ *  parity with memory storage.
+ */
+RemoteStorage.prototype.getAsset = function (filename, callback) {
+  var source = connection.client.download({
+    container: config.assetContainer(),
+    remote: filename
+  });
+  var chunks = [];
+
+  source.on('error', function (err) {
+    callback(err);
+  });
+
+  source.on('data', function (chunk) {
+    chunks.push(chunk);
+  });
+
+  source.on('complete', function (resp) {
+    var complete = Buffer.concat(chunks);
+
+    if (resp.statusCode > 400) {
+      var err = new Error('Cloud Files error');
+
+      err.statusCode = resp.statusCode;
+      err.responseBody = complete;
+
+      return callback(err);
+    }
+
+    callback(null, { contentType: resp.contentType, body: complete });
+  });
+}
+
+/**
  * @description Store a newly generated API key in the keys collection.
  */
 RemoteStorage.prototype.storeKey = function (key, callback) {

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -122,7 +122,7 @@ RemoteStorage.prototype.getAsset = function (filename, callback) {
 
     callback(null, { contentType: resp.contentType, body: complete });
   });
-}
+};
 
 /**
  * @description Store a newly generated API key in the keys collection.


### PR DESCRIPTION
Add an endpoint to allow the content service to act as a content proxy. Uploaded assets are available at `/assets/<filename>`.

I need this to have assets available in local builds, like the client.
