### PR TITLE
Correct content-type handling for binary assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lodash": "^3.8.0",
     "mongodb": "2.0.27",
     "pkgcloud": "1.1.0",
-    "restify": "3.0.0",
+    "restify": "4.0.0",
     "winston": "0.9.0"
   },
   "devDependencies": {

--- a/src/assets.js
+++ b/src/assets.js
@@ -250,11 +250,12 @@ exports.retrieve = function (req, res, next) {
       return next(err);
     }
 
-    res.header('Content-Type', asset.contentType);
-    res.send(asset.body);
+    res.send(200, asset.body, {
+      'Content-Type': asset.contentType
+    });
 
     log.info({
-      action: 'contentretrieve',
+      action: 'assetretrieve',
       statusCode: 200,
       assetFilename: req.params.id,
       assetContentType: asset.contentType,

--- a/src/assets.js
+++ b/src/assets.js
@@ -250,9 +250,10 @@ exports.retrieve = function (req, res, next) {
       return next(err);
     }
 
-    res.send(200, asset.body, {
-      'Content-Type': asset.contentType
-    });
+    res.setHeader('content-type', asset.contentType);
+    res.writeHead(200);
+    res.write(asset.body);
+    res.end();
 
     log.info({
       action: 'assetretrieve',

--- a/src/assets.js
+++ b/src/assets.js
@@ -250,6 +250,7 @@ exports.retrieve = function (req, res, next) {
       return next(err);
     }
 
+    // Bypass restify's formatter to keep it from being "helpful"
     res.setHeader('content-type', asset.contentType);
     res.writeHead(200);
     res.write(asset.body);

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -28,10 +28,7 @@ MemoryStorage.prototype.assetURLPrefix = function () {
 };
 
 MemoryStorage.prototype.storeAsset = function (asset, callback) {
-  var assetBody = '';
-  for (var i = 0; i < asset.chunks.length; i++) {
-    assetBody += asset.chunks[i].toString();
-  }
+  var assetBody = Buffer.concat(asset.chunks);
 
   this.assets[asset.filename] = {
     contentType: asset.type,


### PR DESCRIPTION
Keep restify from "helpfully" overwriting the content-type header and base-64 encoding the response body buffer.
