### PR TITLE
Store the SHA of the latest control repository change

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,49 @@ An HTTP status code of 204 indicates that the API key will no longer be valid.
 *Response: Unsuccessful*
 
 An HTTP status code of 401 indicates that the request did not contain a valid administrator API key. A 409 is generated if an administrator attempts to revoke their own key.
+
+### `PUT /control`
+
+**(Authorization required: any user)**
+
+Change the stored control repository SHA.
+
+*Request*
+
+The request payload must be a JSON object containing a 40-character git commit SHA.
+
+```json
+{
+  "sha": "f2fa39527c7b35b9960fd39e2eb77217db3ee517"
+}
+```
+
+*Response: Successful*
+
+A status code of 204 indicates that the new SHA has been accepted.
+
+*Response: Unsuccessful*
+
+An HTTP status code of 401 indicates that the request did not contain a valid API key. A status code of 400 indicates that the request body did not contain an appropriately formatted JSON document.
+
+### `GET /control`
+
+Retrieve the most recently stored control repository SHA.
+
+*Response: Successful*
+
+If a control repository SHA has been stored:
+
+```json
+{
+  "sha": "f2fa39527c7b35b9960fd39e2eb77217db3ee517"
+}
+```
+
+If no SHA has been stored yet:
+
+```json
+{
+  "sha": null
+}
+```

--- a/script/test
+++ b/script/test
@@ -8,5 +8,6 @@ source ./environment.sh
 export ACTION="test"
 export STORAGE="memory"
 unset INTEGRATION
+unset ADMIN_APIKEY
 
 exec docker-compose up

--- a/src/control.js
+++ b/src/control.js
@@ -10,7 +10,7 @@ exports.store = function (req, res, next) {
     return next(new restify.InvalidContentError('Missing required "sha" attribute'));
   }
 
-  if (! /[0-9a-fA-F]{40}/.test(req.params.sha)) {
+  if (!/[0-9a-fA-F]{40}/.test(req.params.sha)) {
     return next(new restify.InvalidContentError('Not a valid "sha"'));
   }
 
@@ -19,11 +19,11 @@ exports.store = function (req, res, next) {
 
     res.send(204);
 
-    log.info("Stored control repository SHA", {
+    log.info('Stored control repository SHA', {
       sha: req.params.sha
     });
     next();
-  })
+  });
 };
 
 exports.retrieve = function (req, res, next) {};

--- a/src/control.js
+++ b/src/control.js
@@ -26,4 +26,15 @@ exports.store = function (req, res, next) {
   });
 };
 
-exports.retrieve = function (req, res, next) {};
+exports.retrieve = function (req, res, next) {
+  storage.getSHA(function (err, sha) {
+    next.ifError(err);
+
+    res.json(200, {sha: sha});
+
+    log.info('Got control repository SHA', {
+      sha: sha
+    });
+    next();
+  });
+};

--- a/src/control.js
+++ b/src/control.js
@@ -1,0 +1,29 @@
+// Manage the SHA of the latest control repository commit.
+
+var restify = require('restify');
+
+var storage = require('./storage');
+var log = require('./logging').getLogger();
+
+exports.store = function (req, res, next) {
+  if (req.params.sha === undefined) {
+    return next(new restify.InvalidContentError('Missing required "sha" attribute'));
+  }
+
+  if (! /[0-9a-fA-F]{40}/.test(req.params.sha)) {
+    return next(new restify.InvalidContentError('Not a valid "sha"'));
+  }
+
+  storage.storeSHA(req.params.sha, function (err) {
+    next.ifError(err);
+
+    res.send(204);
+
+    log.info("Stored control repository SHA", {
+      sha: req.params.sha
+    });
+    next();
+  })
+};
+
+exports.retrieve = function (req, res, next) {};

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,6 +6,7 @@ var version = require('./version');
 var content = require('./content');
 var assets = require('./assets');
 var keys = require('./keys');
+var control = require('./control');
 
 exports.loadRoutes = function (server) {
   server.get('/version', version.report);
@@ -25,4 +26,7 @@ exports.loadRoutes = function (server) {
 
   server.post('/keys', auth.requireAdmin, restify.queryParser(), keys.issue);
   server.del('/keys/:key', auth.requireAdmin, keys.revoke);
+
+  server.get('/control', control.retrieve);
+  server.put('/control', auth.requireKey, restify.bodyParser(), control.store);
 };

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -20,7 +20,9 @@ var delegates = [
   'findKeys',
   'storeContent',
   'getContent',
-  'deleteContent'
+  'deleteContent',
+  'storeSHA',
+  'getSHA'
 ];
 
 /**

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -120,7 +120,7 @@ MemoryStorage.prototype.deleteContent = function (contentID, callback) {
 MemoryStorage.prototype.storeSHA = function (sha, callback) {
   this.sha = sha;
 
-  callback();
+  callback(null);
 };
 
 MemoryStorage.prototype.getSHA = function (callback) {

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -16,6 +16,7 @@ MemoryStorage.prototype.clear = function (callback) {
   this.assets = {};
   this.namedAssets = {};
   this.keys = {};
+  this.sha = null;
 
   callback();
 };
@@ -114,6 +115,16 @@ MemoryStorage.prototype.deleteContent = function (contentID, callback) {
   delete this.envelopes[contentID];
 
   callback();
+};
+
+MemoryStorage.prototype.storeSHA = function (sha, callback) {
+  this.sha = sha;
+
+  callback();
+};
+
+MemoryStorage.prototype.getSHA = function (callback) {
+  callback(null, this.sha);
 };
 
 module.exports = {

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -200,6 +200,29 @@ RemoteStorage.prototype.deleteContent = function (contentID, callback) {
   connection.client.removeFile(config.contentContainer(), encodeURIComponent(contentID), callback);
 };
 
+RemoteStorage.prototype.storeSHA = function (sha, callback) {
+  connection.db.collection('sha').updateOne({
+    key: 'controlRepository'
+  }, {
+    $set: {
+      key: 'controlRepository',
+      sha: sha
+    }
+  }, {
+    upsert: true
+  }, callback);
+};
+
+RemoteStorage.prototype.getSHA = function (callback) {
+  connection.db.collection('sha').findOne({ key: 'controlRepository'}, function (err, doc) {
+    if (err) {
+      return callback(err);
+    }
+
+    callback(null, doc.sha);
+  });
+};
+
 module.exports = {
   RemoteStorage: RemoteStorage
 };

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -214,7 +214,7 @@ RemoteStorage.prototype.storeSHA = function (sha, callback) {
 };
 
 RemoteStorage.prototype.getSHA = function (callback) {
-  connection.db.collection('sha').findOne({ key: 'controlRepository'}, function (err, doc) {
+  connection.db.collection('sha').findOne({key: 'controlRepository'}, function (err, doc) {
     if (err) {
       return callback(err);
     }

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -219,6 +219,10 @@ RemoteStorage.prototype.getSHA = function (callback) {
       return callback(err);
     }
 
+    if (doc === null) {
+      return callback(null, null);
+    }
+
     callback(null, doc.sha);
   });
 };

--- a/test/assets.js
+++ b/test/assets.js
@@ -88,5 +88,4 @@ describe('/assets', function () {
           .expect(rawAssetContents, done);
       });
   });
-
 });

--- a/test/content.js
+++ b/test/content.js
@@ -51,7 +51,6 @@ describe('/content', function () {
           }),
         done);
     });
-
   });
 
   describe('#retrieve', function () {
@@ -71,7 +70,6 @@ describe('/content', function () {
           }, done);
       });
     });
-
   });
 
   describe('#delete', function () {
@@ -102,6 +100,5 @@ describe('/content', function () {
           .delete('/content/wat%26nope'),
         done);
     });
-
   });
 });

--- a/test/control.js
+++ b/test/control.js
@@ -1,0 +1,72 @@
+/* global describe it beforeEach */
+
+/*
+ * Unit tests for control repository SHA management.
+ */
+
+require('./helpers/before');
+
+var chai = require('chai');
+var dirtyChai = require('dirty-chai');
+
+chai.use(dirtyChai);
+var expect = chai.expect;
+
+var request = require('supertest');
+var storage = require('../src/storage');
+var resetHelper = require('./helpers/reset');
+var authHelper = require('./helpers/auth');
+var server = require('../src/server');
+
+describe('/control', function () {
+  beforeEach(resetHelper);
+
+  describe('PUT', function () {
+    it('requires authentication', function (done) {
+      authHelper.ensureAuthIsRequired(
+        request(server.create())
+          .put('/control')
+          .send({ sha: 'c788b1d16d83c0af023c35df0b9edf04e3e1f3b6' }),
+        done);
+    });
+
+    it('requires a sha element', function (done) {
+      request(server.create())
+        .put('/control')
+        .send({ whoops: 'nope' })
+        .set('Authorization', authHelper.AUTH_USER)
+        .expect(400)
+        .expect({
+          code: 'InvalidContent',
+          message: 'Missing required "sha" attribute'
+        }, done);
+    });
+
+    it('requires a valid git sha', function (done) {
+      request(server.create())
+        .put('/control')
+        .send({ sha: 'not-a-sha' })
+        .set('Authorization', authHelper.AUTH_USER)
+        .expect(400)
+        .expect({
+          code: 'InvalidContent',
+          message: 'Not a valid "sha"'
+        }, done);
+    });
+
+    it('stores a git sha', function (done) {
+      request(server.create())
+        .put('/control')
+        .send({ sha: 'c788b1d16d83c0af023c35df0b9edf04e3e1f3b6' })
+        .set('Authorization', authHelper.AUTH_USER)
+        .expect(204)
+        .expect(function () {
+          storage.getSHA(function (err, sha) {
+            expect(err).to.be.null();
+            expect(sha).to.equal('c788b1d16d83c0af023c35df0b9edf04e3e1f3b6');
+          });
+        })
+        .end(done);
+    });
+  });
+});

--- a/test/control.js
+++ b/test/control.js
@@ -70,7 +70,7 @@ describe('/control', function () {
     });
   });
 
-  describe("GET", function () {
+  describe('GET', function () {
     it('returns null if no git sha has been stored', function (done) {
       request(server.create())
         .get('/control')

--- a/test/control.js
+++ b/test/control.js
@@ -69,4 +69,24 @@ describe('/control', function () {
         .end(done);
     });
   });
+
+  describe("GET", function () {
+    it('returns null if no git sha has been stored', function (done) {
+      request(server.create())
+        .get('/control')
+        .expect(200)
+        .expect({sha: null}, done);
+    });
+
+    it('retrieves a stored git sha', function (done) {
+      storage.storeSHA('c653898a7c864cadb425dc6b19e80e8e276013fc', function (err) {
+        expect(err).to.be.null();
+
+        request(server.create())
+          .get('/control')
+          .expect(200)
+          .expect({sha: 'c653898a7c864cadb425dc6b19e80e8e276013fc'}, done);
+      });
+    });
+  });
 });


### PR DESCRIPTION
The first part of deconst/deconst-docs#134.

Rather than mess around with extra GitHub webhooks and using etcd as a broadcast mechanism, it'll be a lot easier to use the content service to store knowledge of the current control repository SHA. Then we'll be able to keep the control repository updated using the same broadcast mechanisms that we're already using for assets and content: HTTP requests to the content service API.

This'll add API endpoints to the content service to manage this information.
