### PR TITLE
Ignore 400s rather than catch the error.

### DIFF
--- a/src/storage/connection.js
+++ b/src/storage/connection.js
@@ -144,16 +144,8 @@ function elasticInit (callback) {
     }
   };
 
-  client.indices.create({ index: 'envelopes' }, function (err) {
-    if (err) {
-      if (/^IndexAlreadyExistsException/.test(err.message)) {
-        logger.info('Elasticsearch index already exists.', {
-          indexName: 'elastic'
-        });
-      } else {
-        return callback(err);
-      }
-    }
+  client.indices.create({ index: 'envelopes', ignore: 400 }, function (err) {
+    if (err) return callback(err);
 
     client.indices.putMapping({
       index: 'envelopes',


### PR DESCRIPTION
The Elasticsearch client behaved slightly differently on deconst.horse, and I got a thrown exception rather than an `err` that I could catch.
