### PR TITLE
Re-index all content in Elasticsearch on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,3 +235,11 @@ If no SHA has been stored yet:
   "sha": null
 }
 ```
+
+### `POST /reindex`
+
+Asynchronously reindex all content from the primary key-value content store in the full-text search store.
+
+*Response: Successful*
+
+A status code of 202 indicates the reindexing has begun. Watch the container's logs to see indexing progress.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 ---
 elasticsearch:
   image: elasticsearch:1.7
+  ports:
+  - "9200:9200"
 mongo:
   image: mongo:2.6
 content:

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -31,5 +31,5 @@ exports.loadRoutes = function (server) {
   server.get('/control', control.retrieve);
   server.put('/control', auth.requireKey, restify.bodyParser(), control.store);
 
-  server.post('/reindex', auth.requireAdmin, restify.queryParser(), reindex.begin);
+  server.post('/reindex', auth.requireAdmin, reindex.begin);
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,6 +7,7 @@ var content = require('./content');
 var assets = require('./assets');
 var keys = require('./keys');
 var control = require('./control');
+var reindex = require('./reindex');
 
 exports.loadRoutes = function (server) {
   server.get('/version', version.report);
@@ -29,4 +30,6 @@ exports.loadRoutes = function (server) {
 
   server.get('/control', control.retrieve);
   server.put('/control', auth.requireKey, restify.bodyParser(), control.store);
+
+  server.post('/reindex', auth.requireAdmin, restify.queryParser(), reindex.begin);
 };

--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -1,17 +1,91 @@
 // Reindex submitted content from its canonical source.
 
+var async = require('async');
 var storage = require('../storage');
 var log = require('../logging').getLogger();
 
 /**
  * @description Callback to fire when reindexing is complete.
  */
-exports.completedCallback = function (state) {};
+exports.completedCallback = function () {};
+
+/**
+ * @description Enumerate all known content from the active storage implementation. Re-index each
+ *  envelope against the storage. Log progress and record it in a state variable. When complete,
+ *  invoke the completedCallback with the accumulated state.
+ */
+function reindex () {
+  var state = {
+    startedTs: Date.now(),
+    elapsedMs: null,
+    successfulEnvelopes: 0,
+    failedEnvelopes: 0,
+    totalEnvelopes: 0
+  };
+
+  var handleError = function (err, message, fatal) {
+    state.errMessage = err.message;
+    state.stack = err.stack;
+
+    log.error(message, state);
+
+    if (fatal) {
+      exports.completedCallback(err, state);
+    }
+  };
+
+  storage.listContent(function (err, contentIDs, next) {
+    if (err) return handleError(err, 'Unable to list content', true);
+
+    if (contentIDs.length === 0) {
+      // We've listed all of the content. Declare victory in the logs.
+      state.elapsedMs = Date.now() - state.startedTs;
+      log.info('All content re-indexed.', state);
+
+      exports.completedContent(null, state);
+      return;
+    }
+
+    var reindexContentID = function (contentID, cb) {
+      storage.getContent(contentID, function (err, envelope) {
+        if (err) {
+          handleError(err, 'Unable to fetch envelope with ID [' + contentID + ']', false);
+
+          state.failedEnvelopes++;
+          return cb();
+        }
+
+        log.debug('Successful envelope fetch', {
+          contentID: contentID
+        });
+
+        storage.indexContent(contentID, envelope, function (err) {
+          if (err) {
+            handleError(err, 'Unable to index envelope with ID [' + contentID + ']', false);
+            state.failedEnvelopes++;
+            return cb();
+          }
+
+          log.debug('Successful envelope index', {
+            contentID: contentID
+          });
+
+          state.successfulEnvelopes++;
+          cb();
+        });
+      });
+    };
+
+    async.mapLimit(contentIDs, 20, reindexContentID);
+  });
+}
 
 /**
  * @description Trigger an asynchronous reindexing of all content.
  */
 exports.begin = function (req, res, next) {
+  reindex();
+
   res.send(202);
   next();
 };

--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -23,6 +23,8 @@ function reindex () {
     totalEnvelopes: 0
   };
 
+  log.info('Reindex requested', state);
+
   var handleError = function (err, message, fatal) {
     state.errMessage = err.message;
     state.stack = err.stack;
@@ -42,7 +44,7 @@ function reindex () {
       state.elapsedMs = Date.now() - state.startedTs;
       log.info('All content re-indexed.', state);
 
-      exports.completedContent(null, state);
+      exports.completedCallback(null, state);
       return;
     }
 
@@ -52,6 +54,7 @@ function reindex () {
           handleError(err, 'Unable to fetch envelope with ID [' + contentID + ']', false);
 
           state.failedEnvelopes++;
+          state.totalEnvelopes++;
           return cb();
         }
 
@@ -63,6 +66,7 @@ function reindex () {
           if (err) {
             handleError(err, 'Unable to index envelope with ID [' + contentID + ']', false);
             state.failedEnvelopes++;
+            state.totalEnvelopes++;
             return cb();
           }
 
@@ -71,12 +75,13 @@ function reindex () {
           });
 
           state.successfulEnvelopes++;
+          state.totalEnvelopes++;
           cb();
         });
       });
     };
 
-    async.mapLimit(contentIDs, 20, reindexContentID);
+    async.mapLimit(contentIDs, 20, reindexContentID, next);
   });
 }
 

--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -3,13 +3,14 @@
 var storage = require('../storage');
 var log = require('../logging').getLogger();
 
-exports.state = {
-  inProgress: false,
-  reindexedEnvelopes: 0,
-  totalEnvelopes: 0,
-  startedTimestamp: null
-};
+/**
+ * @description Callback to fire when reindexing is complete.
+ */
+exports.completedCallback = function (state) {};
 
+/**
+ * @description Trigger an asynchronous reindexing of all content.
+ */
 exports.begin = function (req, res, next) {
   res.send(202);
   next();

--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -1,0 +1,16 @@
+// Reindex submitted content from its canonical source.
+
+var storage = require('../storage');
+var log = require('../logging').getLogger();
+
+exports.state = {
+  inProgress: false,
+  reindexedEnvelopes: 0,
+  totalEnvelopes: 0,
+  startedTimestamp: null
+};
+
+exports.begin = function (req, res, next) {
+  res.send(202);
+  next();
+};

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -21,6 +21,7 @@ var delegates = exports.delegates = [
   'storeContent',
   'getContent',
   'deleteContent',
+  'listContent',
   'indexContent',
   'storeSHA',
   'getSHA'

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -119,7 +119,7 @@ MemoryStorage.prototype.deleteContent = function (contentID, callback) {
 };
 
 MemoryStorage.prototype.listContent = function (callback) {
-  var ids = Object.keys(this.envelope);
+  var ids = Object.keys(this.envelopes);
 
   callback(null, ids, function () {
     if (ids.length > 0) {

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -118,6 +118,10 @@ MemoryStorage.prototype.deleteContent = function (contentID, callback) {
   callback();
 };
 
+MemoryStorage.prototype.listContent = function (callback) {
+  callback(null, Object.keys(this.envelope));
+};
+
 MemoryStorage.prototype.indexContent = function (contentID, envelope, callback) {
   this.indexedEnvelopes.push({
     id: contentID,

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -119,7 +119,13 @@ MemoryStorage.prototype.deleteContent = function (contentID, callback) {
 };
 
 MemoryStorage.prototype.listContent = function (callback) {
-  callback(null, Object.keys(this.envelope));
+  var ids = Object.keys(this.envelope);
+
+  callback(null, ids, function () {
+    if (ids.length > 0) {
+      callback(null, [], function () {});
+    }
+  });
 };
 
 MemoryStorage.prototype.indexContent = function (contentID, envelope, callback) {

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -212,7 +212,7 @@ RemoteStorage.prototype.listContent = function (callback) {
     connection.client.getFiles(config.contentContainer(), options, function (err, files) {
       if (err) return callback(err);
 
-      var fileNames = files.map(function (e) { return e.name; });
+      var fileNames = files.map(function (e) { return decodeURIComponent(e.name); });
 
       var next = function () {
         // The last page was empty. We're done and we've already sent our done sentinel.
@@ -232,6 +232,8 @@ RemoteStorage.prototype.listContent = function (callback) {
       callback(null, fileNames, next);
     });
   };
+
+  nextPage(null);
 };
 
 RemoteStorage.prototype.indexContent = function (contentID, envelope, callback) {

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -200,6 +200,15 @@ RemoteStorage.prototype.deleteContent = function (contentID, callback) {
   connection.client.removeFile(config.contentContainer(), encodeURIComponent(contentID), callback);
 };
 
+RemoteStorage.prototype.listContent = function (callback) {
+  connection.client.getFiles(config.contentContainer(), { limit: Infinity }, function (err, files) {
+    if (err) return callback(err);
+
+    var fileNames = files.map(function (e) { return e.name; });
+    callback(null, fileNames);
+  });
+};
+
 RemoteStorage.prototype.indexContent = function (contentID, envelope, callback) {
   connection.elastic.index({
     index: 'envelopes',

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -55,7 +55,9 @@ describe('/reindex', function () {
     });
 
     it('reindexes all known content', function (done) {
-      reindex.completedCallback = function (state) {
+      reindex.completedCallback = function (err, state) {
+        expect(err).to.be.null();
+
         expect(indexed.idOne).to.equal('{ "body": "aaa bbb ccc" }');
         expect(indexed.idTwo).to.equal('{ "body": "ddd eee fff" }');
         expect(indexed.idThree).to.equal('{ "body": "ggg hhh iii" }');

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -1,0 +1,28 @@
+/* global describe it beforeEach */
+
+/*
+ * Unit tests for the content service.
+ */
+
+require('./helpers/before');
+
+var chai = require('chai');
+var dirtyChai = require('dirty-chai');
+
+chai.use(dirtyChai);
+var expect = chai.expect;
+
+var request = require('supertest');
+var authHelper = require('./helpers/auth');
+var resetHelper = require('./helpers/reset');
+var server = require('../src/server');
+
+describe('/reindex', function () {
+  beforeEach(resetHelper);
+
+  it('requires an admin key', function (done) {
+    authHelper.ensureAdminIsRequired(
+      request(server.create()).post('/reindex'),
+      done);
+  });
+});

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -58,9 +58,9 @@ describe('/reindex', function () {
       reindex.completedCallback = function (err, state) {
         expect(err).to.be.null();
 
-        expect(indexed.idOne).to.equal('{ "body": "aaa bbb ccc" }');
-        expect(indexed.idTwo).to.equal('{ "body": "ddd eee fff" }');
-        expect(indexed.idThree).to.equal('{ "body": "ggg hhh iii" }');
+        expect(indexed.idOne).to.deep.equal({ title: undefined, body: 'aaa bbb ccc', keywords: '' });
+        expect(indexed.idTwo).to.deep.equal({ title: undefined, body: 'ddd eee fff', keywords: '' });
+        expect(indexed.idThree).to.deep.equal({ title: undefined, body: 'ggg hhh iii', keywords: '' });
 
         expect(state.totalEnvelopes).to.equal(3);
         expect(state.elapsedMs).not.to.be.undefined();

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -68,10 +68,12 @@ describe('/reindex', function () {
         done();
       };
 
-      request(server.create)
+      request(server.create())
         .post('/reindex')
         .set('Authorization', authHelper.AUTH_ADMIN)
-        .expect(202);
+        .expect(202, function (err) {
+          if (err) done(err);
+        });
     });
   });
 });

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -1,4 +1,4 @@
-/* global describe it beforeEach */
+/* global describe it beforeEach afterEach */
 
 /*
  * Unit tests for the content service.
@@ -16,13 +16,60 @@ var request = require('supertest');
 var authHelper = require('./helpers/auth');
 var resetHelper = require('./helpers/reset');
 var server = require('../src/server');
+var storage = require('../src/storage');
+var reindex = require('../src/routes/reindex');
 
 describe('/reindex', function () {
   beforeEach(resetHelper);
+
+  // Sniff the indexContent call.
+  var indexed = null;
+  var realIndexContent = null;
+  beforeEach(function () {
+    indexed = {};
+    realIndexContent = storage.indexContent;
+    storage.indexContent = function (contentID, envelope, callback) {
+      indexed[contentID] = envelope;
+      realIndexContent(contentID, envelope, callback);
+    };
+  });
+  afterEach(function () {
+    storage.indexContent = realIndexContent;
+  });
 
   it('requires an admin key', function (done) {
     authHelper.ensureAdminIsRequired(
       request(server.create()).post('/reindex'),
       done);
+  });
+
+  describe('with content', function () {
+    beforeEach(function (done) {
+      storage.storeContent('idOne', '{ "body": "aaa bbb ccc" }', done);
+    });
+    beforeEach(function (done) {
+      storage.storeContent('idTwo', '{ "body": "ddd eee fff" }', done);
+    });
+    beforeEach(function (done) {
+      storage.storeContent('idThree', '{ "body": "ggg hhh iii" }', done);
+    });
+
+    it('reindexes all known content', function (done) {
+      reindex.completedCallback = function (state) {
+        expect(indexed.idOne).to.equal('{ "body": "aaa bbb ccc" }');
+        expect(indexed.idTwo).to.equal('{ "body": "ddd eee fff" }');
+        expect(indexed.idThree).to.equal('{ "body": "ggg hhh iii" }');
+
+        expect(state.totalEnvelopes).to.equal(3);
+        expect(state.elapsedMs).not.to.be.undefined();
+
+        done();
+      };
+
+      request(server.create)
+        .post('/reindex')
+        .set('Authorization', authHelper.AUTH_ADMIN)
+        .expect(202);
+    });
   });
 });


### PR DESCRIPTION
Using Cloud Files as a source of truth, index all stored content in Elasticsearch. We'll need this for our initial load, but it'll be convenient to have around to support (a) drastic Elasticsearch mapping change, (b) Elasticsearch upgrades, and (c) disaster recovery scenarios.
