### PR TITLE
Remove a misleading log message.

### DIFF
--- a/src/routes/control.js
+++ b/src/routes/control.js
@@ -31,10 +31,6 @@ exports.retrieve = function (req, res, next) {
     next.ifError(err);
 
     res.json(200, {sha: sha});
-
-    log.info('Got control repository SHA', {
-      sha: sha
-    });
     next();
   });
 };


### PR DESCRIPTION
The content service has been logging "Got control repository SHA" over and over again; once per presenter request, as it happens. :hocho: the misleading log message.
