### PR TITLE
Add "event: reindex" to all reindex log messages.

### DIFF
--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -16,6 +16,7 @@ exports.completedCallback = function () {};
  */
 function reindex () {
   var state = {
+    event: 'reindex',
     startedTs: Date.now(),
     elapsedMs: null,
     successfulEnvelopes: 0,
@@ -59,6 +60,7 @@ function reindex () {
         }
 
         log.debug('Successful envelope fetch', {
+          event: 'reindex',
           contentID: contentID
         });
 
@@ -90,6 +92,7 @@ function reindex () {
           }
 
           log.debug('Successful envelope index', {
+            event: 'reindex',
             contentID: contentID
           });
 


### PR DESCRIPTION
This'll make it easier to follow reindexing in Kibana with:

```
SYSTEMD_UNIT:"deconst-content*" AND event:reindex
```
