### PR TITLE
Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,13 @@ If no SHA has been stored yet:
 
 ### `POST /reindex`
 
+**(Authorization required: admin only)**
+
 Asynchronously reindex all content from the primary key-value content store in the full-text search store.
+
+*Response: Unsuccessful*
+
+An HTTP status code of 401 indicates that the request did not contain a valid administrator API key.
 
 *Response: Successful*
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,32 @@ An HTTP status code of 204 indicates that the API key will no longer be valid.
 
 An HTTP status code of 401 indicates that the request did not contain a valid administrator API key. A 409 is generated if an administrator attempts to revoke their own key.
 
+### `GET /search?q=:term&pageNumber=:num&perPage=:size`
+
+Perform a full-text search against all indexed documents.
+
+`q` is a required parameter. `pageNumber` defaults to 1 if unspecified, and `perPage` defaults to 10.
+
+*Response: Successful*
+
+```json
+{
+  "total": 100,
+  "results": [
+    {
+      "contentID": "https://github.com/deconst/deconst-docs/one",
+      "title": "First result title",
+      "excerpt": "body excerpt with matching text <em>highlighted</em>"
+    },
+    {
+      "contentID": "https://github.com/deconst/deconst-docs/two",
+      "title": "Second result title",
+      "excerpt": "first bit of the body if no body content matched"
+    }
+  ]
+}
+```
+
 ### `PUT /control`
 
 **(Authorization required: any user)**

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,6 +8,7 @@ var assets = require('./assets');
 var keys = require('./keys');
 var control = require('./control');
 var reindex = require('./reindex');
+var search = require('./search');
 
 exports.loadRoutes = function (server) {
   server.get('/version', version.report);
@@ -24,6 +25,8 @@ exports.loadRoutes = function (server) {
 
   server.get('/assets', assets.list);
   server.get('/assets/:id', assets.retrieve);
+
+  server.get('/search', search.query);
 
   server.post('/keys', auth.requireAdmin, restify.queryParser(), keys.issue);
   server.del('/keys/:key', auth.requireAdmin, keys.revoke);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -26,7 +26,7 @@ exports.loadRoutes = function (server) {
   server.get('/assets', assets.list);
   server.get('/assets/:id', assets.retrieve);
 
-  server.get('/search', search.query);
+  server.get('/search', restify.queryParser(), search.query);
 
   server.post('/keys', auth.requireAdmin, restify.queryParser(), keys.issue);
   server.del('/keys/:key', auth.requireAdmin, keys.revoke);

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -49,6 +49,8 @@ exports.query = function (req, res, next) {
 
       if (each.highlight.body.length > 0) {
         transformed.excerpt = each.highlight.body[0];
+      } else {
+        transformed.excerpt = each._source.body.substr(0, 150);
       }
 
       return transformed;

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -41,11 +41,20 @@ exports.query = function (req, res, next) {
     logPayload.pageResultCount = results.hits.hits.length;
     logger.info('Successfully completed search', logPayload);
 
-    res.send(200, {
-      results: results.hits.hits.map(function (each) {
-        return { contentID: each._id };
-      })
+    var doc = results.hits.hits.map(function (each) {
+      var transformed = {
+        contentID: each._id,
+        title: each._source.title
+      };
+
+      if (each.highlight.body.length > 0) {
+        transformed.excerpt = each.highlight.body[0];
+      }
+
+      return transformed;
     });
+
+    res.send(200, { results: doc });
     next();
   });
 };

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -54,7 +54,10 @@ exports.query = function (req, res, next) {
       return transformed;
     });
 
-    res.send(200, { results: doc });
+    res.send(200, {
+      total: results.hits.total,
+      results: doc
+    });
     next();
   });
 };

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -30,7 +30,9 @@ exports.query = function (req, res, next) {
     logger.info('Successfully completed search', logPayload);
 
     res.send(200, {
-      results: results.hits.hits.map(function (each) { return each._id; })
+      results: results.hits.hits.map(function (each) {
+        return { contentID: each._id };
+      })
     });
     next();
   });

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -1,0 +1,6 @@
+// Accept full-text search queries
+
+exports.query = function (req, res, next) {
+  res.send(200);
+  next();
+};

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -22,7 +22,8 @@ exports.query = function (req, res, next) {
       logPayload.stack = err.stack;
 
       logger.error('Error performing search', logPayload);
-      return next(restify.InternalServerError('Error performing search'));
+      res.send(new restify.InternalServerError('Error performing search'));
+      return;
     }
 
     logPayload.totalResultCount = results.hits.total;

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -10,7 +10,12 @@ exports.query = function (req, res, next) {
   var pageNumber = req.params.pageNumber || 1;
 
   var startTs = Date.now();
-  var logPayload = {query: q, perPage: perPage, pageNumber: pageNumber};
+  var logPayload = {
+    event: 'search',
+    query: q,
+    perPage: perPage,
+    pageNumber: pageNumber
+  };
 
   logger.debug('Beginning search', logPayload);
 

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -17,6 +17,12 @@ exports.query = function (req, res, next) {
     pageNumber: pageNumber
   };
 
+  if (q === null || q === undefined) {
+    logger.info('Missing required query parameter', logPayload);
+    res.send(new restify.MissingParameterError('q parameter is required'));
+    return;
+  }
+
   logger.debug('Beginning search', logPayload);
 
   storage.queryContent(q, pageNumber, perPage, function (err, results) {

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -23,6 +23,7 @@ var delegates = exports.delegates = [
   'deleteContent',
   'listContent',
   'indexContent',
+  'queryContent',
   'storeSHA',
   'getSHA'
 ];

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -130,11 +130,27 @@ MemoryStorage.prototype.listContent = function (callback) {
 
 MemoryStorage.prototype.indexContent = function (contentID, envelope, callback) {
   this.indexedEnvelopes.push({
-    id: contentID,
+    _id: contentID,
     _source: envelope
   });
 
   callback();
+};
+
+MemoryStorage.prototype.queryContent = function (query, pageNumber, perPage, callback) {
+  var rx = new RegExp(query, 'i');
+
+  var hits = this.indexedEnvelopes.filter(function (entry) {
+    return rx.test([entry._source.title, entry._source.body, entry._source.keywords].join(' '));
+  });
+
+  // Mimic the important parts of the Elasticsearch response.
+  callback(null, {
+    hits: {
+      total: hits.length,
+      hits: hits
+    }
+  });
 };
 
 MemoryStorage.prototype.storeSHA = function (sha, callback) {

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -142,6 +142,17 @@ MemoryStorage.prototype.queryContent = function (query, pageNumber, perPage, cal
 
   var hits = this.indexedEnvelopes.filter(function (entry) {
     return rx.test([entry._source.title, entry._source.body, entry._source.keywords].join(' '));
+  }).map(function (entry) {
+    // Populate "highlights" as just the regexp matches, surrounded by <em> tags.
+    var m = rx.exec(entry._source.body);
+    var highlight = [];
+
+    if (m !== null) {
+      highlight.push('...<em>' + entry._source.body.substr(m.index, m[0].length) + '</em>...');
+    }
+
+    entry.highlight = {body: highlight};
+    return entry;
   });
 
   // Mimic the important parts of the Elasticsearch response.

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -254,6 +254,11 @@ RemoteStorage.prototype.queryContent = function (query, pageNumber, perPage, cal
     body: {
       query: {
         match: { _all: query }
+      },
+      highlight: {
+        fields: {
+          body: {}
+        }
       }
     }
   }, callback);

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -245,6 +245,20 @@ RemoteStorage.prototype.indexContent = function (contentID, envelope, callback) 
   }, callback);
 };
 
+RemoteStorage.prototype.queryContent = function (query, pageNumber, perPage, callback) {
+  connection.elastic.search({
+    index: 'envelopes',
+    from: pageNumber - 1 * perPage,
+    size: perPage,
+    ignoreUnavailable: true,
+    body: {
+      query: {
+        match: { _all: query }
+      }
+    }
+  }, callback);
+};
+
 RemoteStorage.prototype.storeSHA = function (sha, callback) {
   connection.db.collection('sha').updateOne({
     key: 'controlRepository'

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -248,7 +248,7 @@ RemoteStorage.prototype.indexContent = function (contentID, envelope, callback) 
 RemoteStorage.prototype.queryContent = function (query, pageNumber, perPage, callback) {
   connection.elastic.search({
     index: 'envelopes',
-    from: pageNumber - 1 * perPage,
+    from: (pageNumber - 1) * perPage,
     size: perPage,
     ignoreUnavailable: true,
     body: {

--- a/test/search.js
+++ b/test/search.js
@@ -11,13 +11,13 @@ describe('/search', function () {
   beforeEach(resetHelper);
 
   beforeEach(function (done) {
-    storage.storeContent('foo/aaa', '{ "body": "all aaa" }', done);
+    storage.indexContent('foo/aaa', { title: undefined, body: 'all aaa', keywords: '' }, done);
   });
   beforeEach(function (done) {
-    storage.storeContent('foo/bbb', '{ "body": "all bbb" }', done);
+    storage.indexContent('foo/bbb', { title: undefined, body: 'all bbb', keywords: '' }, done);
   });
   beforeEach(function (done) {
-    storage.storeContent('foo/ccc', '{ "body": "all ccc" }', done);
+    storage.indexContent('foo/ccc', { title: undefined, body: 'all ccc', keywords: '' }, done);
   });
 
   it('returns IDs of matching documents', function (done) {

--- a/test/search.js
+++ b/test/search.js
@@ -11,13 +11,13 @@ describe('/search', function () {
   beforeEach(resetHelper);
 
   beforeEach(function (done) {
-    storage.indexContent('foo/aaa', { title: undefined, body: 'all aaa', keywords: '' }, done);
+    storage.indexContent('foo/aaa', { title: 'first', body: 'all aaa', keywords: '' }, done);
   });
   beforeEach(function (done) {
-    storage.indexContent('foo/bbb', { title: undefined, body: 'all bbb', keywords: '' }, done);
+    storage.indexContent('foo/bbb', { title: 'second', body: 'all bbb', keywords: '' }, done);
   });
   beforeEach(function (done) {
-    storage.indexContent('foo/ccc', { title: undefined, body: 'all ccc', keywords: '' }, done);
+    storage.indexContent('foo/ccc', { title: 'third', body: 'all ccc', keywords: '' }, done);
   });
 
   it('returns IDs of matching documents', function (done) {
@@ -26,9 +26,21 @@ describe('/search', function () {
       .expect(200)
       .expect({
         results: [
-          { contentID: 'foo/aaa' },
-          { contentID: 'foo/bbb' },
-          { contentID: 'foo/ccc' }
+          {
+            contentID: 'foo/aaa',
+            title: 'first',
+            excerpt: '...<em>all</em>...'
+          },
+          {
+            contentID: 'foo/bbb',
+            title: 'second',
+            excerpt: '...<em>all</em>...'
+          },
+          {
+            contentID: 'foo/ccc',
+            title: 'third',
+            excerpt: '...<em>all</em>...'
+          }
         ]
       }, done);
   });

--- a/test/search.js
+++ b/test/search.js
@@ -25,6 +25,7 @@ describe('/search', function () {
       .get('/search?q=all')
       .expect(200)
       .expect({
+        total: 3,
         results: [
           {
             contentID: 'foo/aaa',

--- a/test/search.js
+++ b/test/search.js
@@ -32,4 +32,10 @@ describe('/search', function () {
         ]
       }, done);
   });
+
+  it('responds with a 409 if no query is provided', function (done) {
+    request(server.create())
+      .get('/search')
+      .expect(409, done);
+  });
 });

--- a/test/search.js
+++ b/test/search.js
@@ -1,0 +1,35 @@
+/* global describe it beforeEach */
+
+require('./helpers/before');
+
+var request = require('supertest');
+var resetHelper = require('./helpers/reset');
+var storage = require('../src/storage');
+var server = require('../src/server');
+
+describe('/search', function () {
+  beforeEach(resetHelper);
+
+  beforeEach(function (done) {
+    storage.storeContent('foo/aaa', '{ "body": "all aaa" }', done);
+  });
+  beforeEach(function (done) {
+    storage.storeContent('foo/bbb', '{ "body": "all bbb" }', done);
+  });
+  beforeEach(function (done) {
+    storage.storeContent('foo/ccc', '{ "body": "all ccc" }', done);
+  });
+
+  it('returns IDs of matching documents', function (done) {
+    request(server.create())
+      .get('/search?q=all')
+      .expect(200)
+      .expect({
+        results: [
+          { contentID: 'foo/aaa' },
+          { contentID: 'foo/bbb' },
+          { contentID: 'foo/ccc' }
+        ]
+      }, done);
+  });
+});


### PR DESCRIPTION
API for _consuming_ search across indexed documents. The next part of deconst/deconst-docs#187.
- [x] Generate a 400 response if no query term is provided.
- [x] Include titles and body excerpts.
- [x] Test the service with remote storage enabled and ensure that my mocks are consistent with the real Elasticsearch API.
- [x] Include the total result count in the results.
- [x] Update API documentation in the README.
