### PR TITLE
Trim HTML from content before full-text indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "0.9.0",
+    "cheerio": "^0.19.0",
     "elasticsearch": "^9.0.2",
     "lodash": "^3.8.0",
     "mongodb": "2.0.27",

--- a/src/routes/content.js
+++ b/src/routes/content.js
@@ -57,15 +57,7 @@ exports.store = function (req, res, next) {
 
   // Index the envelope in the full text search storage engine.
   var ftsStore = function (cb) {
-    var kws = envelope.keywords || [];
-
-    var subset = {
-      title: envelope.title,
-      body: envelope.body,
-      keywords: kws.join(' ')
-    };
-
-    storage.indexContent(contentID, subset, cb);
+    storage.indexContent(contentID, envelope, cb);
   };
 
   async.parallel([

--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -75,15 +75,7 @@ function reindex () {
           return cb();
         }
 
-        var kws = envelope.keywords || [];
-
-        var subset = {
-          title: envelope.title,
-          body: envelope.body,
-          keywords: kws.join(' ')
-        };
-
-        storage.indexContent(contentID, subset, function (err) {
+        storage.indexContent(contentID, envelope, function (err) {
           if (err) {
             handleError(err, 'Unable to index envelope with ID [' + contentID + ']', false);
             state.failedEnvelopes++;

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -2,6 +2,7 @@
  * Interfaces between the API and the underlying storage engines.
  */
 
+var cheerio = require('cheerio');
 var config = require('../config');
 var memory = require('./memory');
 var remote = require('./remote');
@@ -80,10 +81,13 @@ exports.setup = function (callback) {
 
 exports.indexContent = function (contentID, envelope, callback) {
   var kws = envelope.keywords || [];
+  var $ = cheerio.load(envelope.body, {
+    normalizeWhitespace: true
+  });
 
   var subset = {
     title: envelope.title || '',
-    body: envelope.body,
+    body: $.root().text(),
     keywords: kws.join(' ')
   };
 

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -22,7 +22,7 @@ var delegates = exports.delegates = [
   'getContent',
   'deleteContent',
   'listContent',
-  'indexContent',
+  '_indexContent',
   'queryContent',
   'storeSHA',
   'getSHA'
@@ -74,4 +74,8 @@ exports.setup = function (callback) {
 
     callback(null);
   });
+};
+
+exports.indexContent = function (contentID, envelope, callback) {
+  exports._indexContent(contentID, envelope, callback);
 };

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -76,6 +76,16 @@ exports.setup = function (callback) {
   });
 };
 
+// Facade functions to perform common input preprocessing.
+
 exports.indexContent = function (contentID, envelope, callback) {
-  exports._indexContent(contentID, envelope, callback);
+  var kws = envelope.keywords || [];
+
+  var subset = {
+    title: envelope.title || '',
+    body: envelope.body,
+    keywords: kws.join(' ')
+  };
+
+  exports._indexContent(contentID, subset, callback);
 };

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -128,7 +128,7 @@ MemoryStorage.prototype.listContent = function (callback) {
   });
 };
 
-MemoryStorage.prototype.indexContent = function (contentID, envelope, callback) {
+MemoryStorage.prototype._indexContent = function (contentID, envelope, callback) {
   this.indexedEnvelopes.push({
     _id: contentID,
     _source: envelope

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -236,7 +236,7 @@ RemoteStorage.prototype.listContent = function (callback) {
   nextPage(null);
 };
 
-RemoteStorage.prototype.indexContent = function (contentID, envelope, callback) {
+RemoteStorage.prototype._indexContent = function (contentID, envelope, callback) {
   connection.elastic.index({
     index: 'envelopes',
     type: 'envelope',

--- a/test/content.js
+++ b/test/content.js
@@ -28,14 +28,14 @@ describe('/content', function () {
         .set('Authorization', authHelper.AUTH_USER)
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json')
-        .send('{ "something": "body" }')
+        .send('{ "body": "something" }')
         .expect(204)
         .end(function (err, res) {
           if (err) return done(err);
 
           storage.getContent('foo&bar', function (err, uploaded) {
             expect(err).to.be.null();
-            expect(JSON.parse(uploaded)).to.deep.equal({ something: 'body' });
+            expect(JSON.parse(uploaded)).to.deep.equal({ body: 'something' });
 
             done();
           });

--- a/test/content.js
+++ b/test/content.js
@@ -47,20 +47,39 @@ describe('/content', function () {
         .put('/content/foobar')
         .set('Authorization', authHelper.AUTH_USER)
         .set('Content-Type', 'application/json')
-        .set('Accept', 'applicaiton/json')
-        .send('{ "title": "aaa", "body": "<p class=\'nope\'>bbb ccc ddd</p>" }')
+        .set('Accept', 'application/json')
+        .send('{ "title": "aaa", "body": "bbb ccc ddd" }')
         .expect(204)
         .end(function (err, res) {
           if (err) return done(err);
 
           storage.queryContent('ccc', 1, 10, function (err, results) {
-            console.log(require('util').inspect(results, { depth: null }));
             expect(err).to.be.null();
             expect(results.hits.total).to.equal(1);
 
             var result = results.hits.hits[0];
             expect(result._id).to.equal('foobar');
             expect(result._source.title).to.equal('aaa');
+
+            done();
+          });
+        });
+    });
+
+    it('trims HTML from content before full-text indexing', function (done) {
+      request(server.create())
+        .put('/content/foobar')
+        .set('Authorization', authHelper.AUTH_USER)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .send('{ "title": "aaa", "body": "<p class=\'nope\'>bbb ccc ddd</p>" }')
+        .expect(204)
+        .end(function (err, res) {
+          if (err) return done(err);
+
+          storage.queryContent('nope', 1, 10, function (err, results) {
+            expect(err).to.be.null();
+            expect(results.hits.total).to.equal(0);
 
             done();
           });

--- a/test/content.js
+++ b/test/content.js
@@ -42,6 +42,31 @@ describe('/content', function () {
         });
     });
 
+    it('makes the content available to full-text search', function (done) {
+      request(server.create())
+        .put('/content/foobar')
+        .set('Authorization', authHelper.AUTH_USER)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'applicaiton/json')
+        .send('{ "title": "aaa", "body": "<p class=\'nope\'>bbb ccc ddd</p>" }')
+        .expect(204)
+        .end(function (err, res) {
+          if (err) return done(err);
+
+          storage.queryContent('ccc', 1, 10, function (err, results) {
+            console.log(require('util').inspect(results, { depth: null }));
+            expect(err).to.be.null();
+            expect(results.hits.total).to.equal(1);
+
+            var result = results.hits.hits[0];
+            expect(result._id).to.equal('foobar');
+            expect(result._source.title).to.equal('aaa');
+
+            done();
+          });
+        });
+    });
+
     it('requires authentication', function (done) {
       authHelper.ensureAuthIsRequired(
         request(server.create())

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -27,14 +27,14 @@ describe('/reindex', function () {
   var realIndexContent = null;
   beforeEach(function () {
     indexed = {};
-    realIndexContent = storage.indexContent;
-    storage.indexContent = function (contentID, envelope, callback) {
+    realIndexContent = storage._indexContent;
+    storage._indexContent = function (contentID, envelope, callback) {
       indexed[contentID] = envelope;
       realIndexContent(contentID, envelope, callback);
     };
   });
   afterEach(function () {
-    storage.indexContent = realIndexContent;
+    storage._indexContent = realIndexContent;
   });
 
   it('requires an admin key', function (done) {
@@ -58,9 +58,9 @@ describe('/reindex', function () {
       reindex.completedCallback = function (err, state) {
         expect(err).to.be.null();
 
-        expect(indexed.idOne).to.deep.equal({ title: undefined, body: 'aaa bbb ccc', keywords: '' });
-        expect(indexed.idTwo).to.deep.equal({ title: undefined, body: 'ddd eee fff', keywords: '' });
-        expect(indexed.idThree).to.deep.equal({ title: undefined, body: 'ggg hhh iii', keywords: '' });
+        expect(indexed.idOne).to.deep.equal({ title: '', body: 'aaa bbb ccc', keywords: '' });
+        expect(indexed.idTwo).to.deep.equal({ title: '', body: 'ddd eee fff', keywords: '' });
+        expect(indexed.idThree).to.deep.equal({ title: '', body: 'ggg hhh iii', keywords: '' });
 
         expect(state.totalEnvelopes).to.equal(3);
         expect(state.elapsedMs).not.to.be.undefined();


### PR DESCRIPTION
To prevent weird things like getting search hits from DOM element attributes or result excerpts containing broken markup.

In support of deconst/deconst-docs#187.
