### PR TITLE
Use facade functions to centralize input preprocessing

### DIFF
--- a/src/routes/content.js
+++ b/src/routes/content.js
@@ -52,7 +52,7 @@ exports.store = function (req, res, next) {
 
   // Store the envelope in the primary key-value storage engine.
   var kvStore = function (cb) {
-    storage.storeContent(contentID, JSON.stringify(envelope), cb);
+    storage.storeContent(contentID, envelope, cb);
   };
 
   // Index the envelope in the full text search storage engine.

--- a/src/routes/content.js
+++ b/src/routes/content.js
@@ -9,14 +9,10 @@ var log = require('../logging').getLogger();
  * @description Download the raw metadata envelope from Cloud Files.
  */
 function downloadContent (contentID, callback) {
-  storage.getContent(contentID, function (err, content) {
+  storage.getContent(contentID, function (err, envelope) {
     if (err) return callback(err);
 
-    var envelope = JSON.parse(content);
-
-    callback(null, {
-      envelope: envelope
-    });
+    callback(null, { envelope: envelope });
   });
 }
 

--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -50,7 +50,7 @@ function reindex () {
     }
 
     var reindexContentID = function (contentID, cb) {
-      storage.getContent(contentID, function (err, doc) {
+      storage.getContent(contentID, function (err, envelope) {
         if (err) {
           handleError(err, 'Unable to fetch envelope with ID [' + contentID + ']', false);
 
@@ -63,17 +63,6 @@ function reindex () {
           event: 'reindex',
           contentID: contentID
         });
-
-        var envelope = null;
-        try {
-          envelope = JSON.parse(doc);
-        } catch (err) {
-          handleError(err, 'Unable to parse envelope with ID [' + contentID + ']', false);
-
-          state.failedEnvelopes++;
-          state.totalEnvelopes++;
-          return cb();
-        }
 
         storage.indexContent(contentID, envelope, function (err) {
           if (err) {

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -84,7 +84,17 @@ exports.storeContent = function (contentID, envelope, callback) {
 };
 
 exports.getContent = function (contentID, callback) {
-  exports._getContent(contentID, callback);
+  exports._getContent(contentID, function (err, raw) {
+    if (err) return callback(err);
+
+    try {
+      var envelope = JSON.parse(raw);
+    } catch (e) {
+      return callback(e);
+    }
+
+    callback(null, envelope);
+  });
 };
 
 exports.indexContent = function (contentID, envelope, callback) {

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -80,7 +80,7 @@ exports.setup = function (callback) {
 // Facade functions to perform common input preprocessing.
 
 exports.storeContent = function (contentID, envelope, callback) {
-  exports._storeContent(contentID, envelope, callback);
+  exports._storeContent(contentID, JSON.stringify(envelope), callback);
 };
 
 exports.indexContent = function (contentID, envelope, callback) {

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -19,7 +19,7 @@ var delegates = exports.delegates = [
   'storeKey',
   'deleteKey',
   'findKeys',
-  'storeContent',
+  '_storeContent',
   'getContent',
   'deleteContent',
   'listContent',
@@ -78,6 +78,10 @@ exports.setup = function (callback) {
 };
 
 // Facade functions to perform common input preprocessing.
+
+exports.storeContent = function (contentID, envelope, callback) {
+  exports._storeContent(contentID, envelope, callback);
+};
 
 exports.indexContent = function (contentID, envelope, callback) {
   var kws = envelope.keywords || [];

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -20,7 +20,7 @@ var delegates = exports.delegates = [
   'deleteKey',
   'findKeys',
   '_storeContent',
-  'getContent',
+  '_getContent',
   'deleteContent',
   'listContent',
   '_indexContent',
@@ -81,6 +81,10 @@ exports.setup = function (callback) {
 
 exports.storeContent = function (contentID, envelope, callback) {
   exports._storeContent(contentID, JSON.stringify(envelope), callback);
+};
+
+exports.getContent = function (contentID, callback) {
+  exports._getContent(contentID, callback);
 };
 
 exports.indexContent = function (contentID, envelope, callback) {

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -97,7 +97,7 @@ MemoryStorage.prototype._storeContent = function (contentID, content, callback) 
   callback();
 };
 
-MemoryStorage.prototype.getContent = function (contentID, callback) {
+MemoryStorage.prototype._getContent = function (contentID, callback) {
   var envelope = this.envelopes[contentID];
 
   if (envelope === undefined) {

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -92,7 +92,7 @@ MemoryStorage.prototype.findKeys = function (apikey, callback) {
   }
 };
 
-MemoryStorage.prototype.storeContent = function (contentID, content, callback) {
+MemoryStorage.prototype._storeContent = function (contentID, content, callback) {
   this.envelopes[contentID] = content;
   callback();
 };

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -165,7 +165,7 @@ RemoteStorage.prototype._storeContent = function (contentID, content, callback) 
   dest.end(content);
 };
 
-RemoteStorage.prototype.getContent = function (contentID, callback) {
+RemoteStorage.prototype._getContent = function (contentID, callback) {
   var source = connection.client.download({
     container: config.contentContainer(),
     remote: encodeURIComponent(contentID)

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -150,7 +150,7 @@ RemoteStorage.prototype.findKeys = function (apikey, callback) {
   }).toArray(callback);
 };
 
-RemoteStorage.prototype.storeContent = function (contentID, content, callback) {
+RemoteStorage.prototype._storeContent = function (contentID, content, callback) {
   var dest = connection.client.upload({
     container: config.contentContainer(),
     remote: encodeURIComponent(contentID)

--- a/test/content.js
+++ b/test/content.js
@@ -99,7 +99,7 @@ describe('/content', function () {
 
   describe('#retrieve', function () {
     it('retrieves existing content from Cloud Files', function (done) {
-      storage.storeContent('what&huh', '{ "expected": "json" }', function (err) {
+      storage.storeContent('what&huh', { body: 'expected' }, function (err) {
         expect(err).not.to.exist();
 
         request(server.create())
@@ -109,7 +109,7 @@ describe('/content', function () {
           .expect({
             assets: [],
             envelope: {
-              expected: 'json'
+              body: 'expected'
             }
           }, done);
       });
@@ -118,7 +118,7 @@ describe('/content', function () {
 
   describe('#delete', function () {
     it('deletes content from Cloud Files', function (done) {
-      storage.storeContent('er&okay', '{ "expected": "json" }', function (err) {
+      storage.storeContent('er&okay', { body: 'expected' }, function (err) {
         expect(err).not.to.exist();
 
         request(server.create())

--- a/test/content.js
+++ b/test/content.js
@@ -35,7 +35,7 @@ describe('/content', function () {
 
           storage.getContent('foo&bar', function (err, uploaded) {
             expect(err).to.be.null();
-            expect(JSON.parse(uploaded)).to.deep.equal({ body: 'something' });
+            expect(uploaded).to.deep.equal({ body: 'something' });
 
             done();
           });

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -45,13 +45,13 @@ describe('/reindex', function () {
 
   describe('with content', function () {
     beforeEach(function (done) {
-      storage.storeContent('idOne', '{ "body": "aaa bbb ccc" }', done);
+      storage.storeContent('idOne', { body: 'aaa bbb ccc' }, done);
     });
     beforeEach(function (done) {
-      storage.storeContent('idTwo', '{ "body": "ddd eee fff" }', done);
+      storage.storeContent('idTwo', { body: 'ddd eee fff' }, done);
     });
     beforeEach(function (done) {
-      storage.storeContent('idThree', '{ "body": "ggg hhh iii" }', done);
+      storage.storeContent('idThree', { body: 'ggg hhh iii' }, done);
     });
 
     it('reindexes all known content', function (done) {


### PR DESCRIPTION
We have a few storage functions that are always called with the same pre- or postprocessing. Introduce facade functions to reduce duplications of all of that logic.
