### PR TITLE
Don't index envelopes that specify "unsearchable: true".

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -99,6 +99,11 @@ exports.getContent = function (contentID, callback) {
 };
 
 exports.indexContent = function (contentID, envelope, callback) {
+  // Skip envelopes that have "unsearchable" set to true.
+  if (envelope.unsearchable) {
+    return callback(null);
+  }
+
   var kws = envelope.keywords || [];
   var $ = cheerio.load(envelope.body, {
     normalizeWhitespace: true

--- a/test/content.js
+++ b/test/content.js
@@ -86,6 +86,26 @@ describe('/content', function () {
         });
     });
 
+    it('skips envelopes with unsearchable set to true', function (done) {
+      request(server.create())
+        .put('/content/foobar')
+        .set('Authorization', authHelper.AUTH_USER)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .send('{ "title": "aaa", "body": "bbb ccc ddd", "unsearchable": true }')
+        .expect(204)
+        .end(function (err, res) {
+          if (err) return done(err);
+
+          storage.queryContent('ccc', 1, 10, function (err, results) {
+            expect(err).to.be.null();
+            expect(results.hits.total).to.equal(0);
+
+            done();
+          });
+        });
+    });
+
     it('requires authentication', function (done) {
       authHelper.ensureAuthIsRequired(
         request(server.create())


### PR DESCRIPTION
Allow individual metadata envelopes to opt out of full-text search indexing. This is useful for:
1. Content like the RSS or Atom feeds.
2. Content that's being prepared, but is not yet mapped.

Note that until I get to deconst/deconst-docs#133, you won't be able to retroactively remove something from the search index by flipping `unsearchable` to true on _existing_ documents. We'd have to manually delete them from Elasticsearch.
- [x] Update the metadata envelope schema in the docs.
- [ ] Generate the `unsearchable` attribute in the Jekyll and Sphinx preparers.

I think this is the last bit of deconst/deconst-docs#187.
