### PR TITLE
Constrain search by categories

### DIFF
--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -8,13 +8,15 @@ exports.query = function (req, res, next) {
   var q = req.params.q;
   var perPage = req.params.perPage || 10;
   var pageNumber = req.params.pageNumber || 1;
+  var categories = req.params.categories;
 
   var startTs = Date.now();
   var logPayload = {
     event: 'search',
     query: q,
     perPage: perPage,
-    pageNumber: pageNumber
+    pageNumber: pageNumber,
+    categories: categories
   };
 
   if (q === null || q === undefined) {
@@ -25,7 +27,7 @@ exports.query = function (req, res, next) {
 
   logger.debug('Beginning search', logPayload);
 
-  storage.queryContent(q, pageNumber, perPage, function (err, results) {
+  storage.queryContent(q, categories, pageNumber, perPage, function (err, results) {
     logPayload.duration = Date.now() - startTs;
 
     if (err) {

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -10,6 +10,10 @@ exports.query = function (req, res, next) {
   var pageNumber = req.params.pageNumber || 1;
   var categories = req.params.categories;
 
+  if (typeof categories === 'string') {
+    categories = [categories];
+  }
+
   var startTs = Date.now();
   var logPayload = {
     event: 'search',

--- a/src/storage/connection.js
+++ b/src/storage/connection.js
@@ -140,7 +140,8 @@ function elasticInit (callback) {
     properties: {
       title: { type: 'string', index: 'analyzed' },
       body: { type: 'string', index: 'analyzed' },
-      keywords: { type: 'string', index: 'analyzed' }
+      keywords: { type: 'string', index: 'analyzed' },
+      categories: { type: 'string', index: 'not_analyzed' }
     }
   };
 

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -112,7 +112,8 @@ exports.indexContent = function (contentID, envelope, callback) {
   var subset = {
     title: envelope.title || '',
     body: $.root().text(),
-    keywords: kws.join(' ')
+    keywords: kws.join(' '),
+    categories: envelope.categories || []
   };
 
   exports._indexContent(contentID, subset, callback);

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -137,10 +137,16 @@ MemoryStorage.prototype._indexContent = function (contentID, envelope, callback)
   callback();
 };
 
-MemoryStorage.prototype.queryContent = function (query, pageNumber, perPage, callback) {
+MemoryStorage.prototype.queryContent = function (query, categories, pageNumber, perPage, callback) {
   var rx = new RegExp(query, 'i');
 
   var hits = this.indexedEnvelopes.filter(function (entry) {
+    if (categories) {
+      if (_.intersection(categories, entry._source.categories).length === 0) {
+        return false;
+      }
+    }
+
     return rx.test([entry._source.title, entry._source.body, entry._source.keywords].join(' '));
   }).map(function (entry) {
     // Populate "highlights" as just the regexp matches, surrounded by <em> tags.

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -259,7 +259,7 @@ RemoteStorage.prototype.queryContent = function (query, categories, pageNumber, 
     q.match = { _all: query };
   } else {
     q.filtered = {
-      query: { _all: query },
+      query: { match: { _all: query } },
       filter: { terms: { category: categories } }
     };
   }

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -252,16 +252,25 @@ RemoteStorage.prototype._indexContent = function (contentID, envelope, callback)
   }, callback);
 };
 
-RemoteStorage.prototype.queryContent = function (query, pageNumber, perPage, callback) {
+RemoteStorage.prototype.queryContent = function (query, categories, pageNumber, perPage, callback) {
+  var q = {};
+
+  if (!categories) {
+    q.match = { _all: query };
+  } else {
+    q.filtered = {
+      query: { _all: query },
+      filter: { terms: { category: categories } }
+    };
+  }
+
   connection.elastic.search({
     index: 'envelopes',
     from: (pageNumber - 1) * perPage,
     size: perPage,
     ignoreUnavailable: true,
     body: {
-      query: {
-        match: { _all: query }
-      },
+      query: q,
       highlight: {
         fields: {
           body: {}

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -260,12 +260,13 @@ RemoteStorage.prototype.queryContent = function (query, categories, pageNumber, 
   } else {
     q.filtered = {
       query: { match: { _all: query } },
-      filter: { terms: { category: categories } }
+      filter: { terms: { categories: categories } }
     };
   }
 
   connection.elastic.search({
     index: 'envelopes',
+    type: 'envelope',
     from: (pageNumber - 1) * perPage,
     size: perPage,
     ignoreUnavailable: true,

--- a/test/content.js
+++ b/test/content.js
@@ -53,7 +53,7 @@ describe('/content', function () {
         .end(function (err, res) {
           if (err) return done(err);
 
-          storage.queryContent('ccc', 1, 10, function (err, results) {
+          storage.queryContent('ccc', null, 1, 10, function (err, results) {
             expect(err).to.be.null();
             expect(results.hits.total).to.equal(1);
 
@@ -77,7 +77,7 @@ describe('/content', function () {
         .end(function (err, res) {
           if (err) return done(err);
 
-          storage.queryContent('nope', 1, 10, function (err, results) {
+          storage.queryContent('nope', null, 1, 10, function (err, results) {
             expect(err).to.be.null();
             expect(results.hits.total).to.equal(0);
 
@@ -97,7 +97,7 @@ describe('/content', function () {
         .end(function (err, res) {
           if (err) return done(err);
 
-          storage.queryContent('ccc', 1, 10, function (err, results) {
+          storage.queryContent('ccc', null, 1, 10, function (err, results) {
             expect(err).to.be.null();
             expect(results.hits.total).to.equal(0);
 
@@ -176,7 +176,7 @@ describe('/content', function () {
         .end(function (err, res) {
           if (err) return done(err);
 
-          storage.queryContent('expected', 1, 10, function (err, found) {
+          storage.queryContent('expected', null, 1, 10, function (err, found) {
             expect(err).to.be.null();
             expect(found.hits.total).to.equal(0);
             expect(found.hits.hits.length).to.equal(0);

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -58,9 +58,9 @@ describe('/reindex', function () {
       reindex.completedCallback = function (err, state) {
         expect(err).to.be.null();
 
-        expect(indexed.idOne).to.deep.equal({ title: '', body: 'aaa bbb ccc', keywords: '' });
-        expect(indexed.idTwo).to.deep.equal({ title: '', body: 'ddd eee fff', keywords: '' });
-        expect(indexed.idThree).to.deep.equal({ title: '', body: 'ggg hhh iii', keywords: '' });
+        expect(indexed.idOne).to.deep.equal({ title: '', body: 'aaa bbb ccc', keywords: '', categories: [] });
+        expect(indexed.idTwo).to.deep.equal({ title: '', body: 'ddd eee fff', keywords: '', categories: [] });
+        expect(indexed.idThree).to.deep.equal({ title: '', body: 'ggg hhh iii', keywords: '', categories: [] });
 
         expect(state.totalEnvelopes).to.equal(3);
         expect(state.elapsedMs).not.to.be.undefined();


### PR DESCRIPTION
Use an optional `categories` parameter to constrain a full-text search to a subset of the available documents.

The next bit of deconst/deconst-docs#187.
