### PR TITLE
Handle trailing slashes

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -10,14 +10,16 @@ var log = require('./logging').getLogger();
 exports.create = function () {
   var server = restify.createServer();
 
+  server.pre(restify.pre.sanitizePath());
+
   server.name = config.info.name;
 
-  server
-    .use(function (req, res, next) {
-      log.verbose(req.method + ' ' + req.url);
-      next();
-    })
-    .use(restify.fullResponse());
+  server.use(function (req, res, next) {
+    log.verbose(req.method + ' ' + req.url);
+    next();
+  });
+
+  server.use(restify.fullResponse());
 
   server.on('uncaughtException', function (req, res, route, err) {
     log.error({

--- a/test/assets.js
+++ b/test/assets.js
@@ -88,4 +88,10 @@ describe('/assets', function () {
           .expect(rawAssetContents, done);
       });
   });
+
+  it("doesn't crash with a trailing slash", function (done) {
+    request(server.create())
+      .get('/assets/')
+      .expect(200, done);
+  });
 });

--- a/test/content.js
+++ b/test/content.js
@@ -24,7 +24,7 @@ describe('/content', function () {
   describe('#store', function () {
     it('persists new content into Cloud Files', function (done) {
       request(server.create())
-        .put('/content/foo%26bar')
+        .put('/content/foo%26bar%2F')
         .set('Authorization', authHelper.AUTH_USER)
         .set('Content-Type', 'application/json')
         .set('Accept', 'application/json')
@@ -33,7 +33,7 @@ describe('/content', function () {
         .end(function (err, res) {
           if (err) return done(err);
 
-          storage.getContent('foo&bar', function (err, uploaded) {
+          storage.getContent('foo&bar/', function (err, uploaded) {
             expect(err).to.be.null();
             expect(uploaded).to.deep.equal({ body: 'something' });
 


### PR DESCRIPTION
When I'm used to hitting presenter APIs with curl and then I flip over to content service work, I always forget and leave trailing slashes on URLs, which makes the content service :boom:. Let's canonicalize then without a trailing slash.

Fixes deconst/deconst-docs#200.
