### PR TITLE
/reindex content into a new index and update an alias

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 ---
 language: node_js
 node_js:
-- "0.12.1"
+- "4.3.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12.1
+FROM node:4.3.1
 
 RUN useradd node
 RUN npm install -g nodemon

--- a/script/inside/dev
+++ b/script/inside/dev
@@ -19,6 +19,6 @@ case "${ACTION}" in
     npm test
     ;;
   *)
-    nodemon app.js
+    exec nodemon app.js
     ;;
 esac

--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -17,7 +17,7 @@ exports.completedCallback = function () {};
  *  invoke the completedCallback with the accumulated state.
  */
 function reindex () {
-  let indexName = `envelopes-${Date.now()}`;
+  let indexName = `envelopes_${Date.now()}`;
 
   let state = {
     event: 'reindex',

--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Reindex submitted content from its canonical source.
 
 var async = require('async');
@@ -15,8 +17,11 @@ exports.completedCallback = function () {};
  *  invoke the completedCallback with the accumulated state.
  */
 function reindex () {
-  var state = {
+  let indexName = `envelopes-${Date.now()}`;
+
+  let state = {
     event: 'reindex',
+    indexName: indexName,
     startedTs: Date.now(),
     elapsedMs: null,
     successfulEnvelopes: 0,
@@ -26,7 +31,7 @@ function reindex () {
 
   log.info('Reindex requested', state);
 
-  var handleError = function (err, message, fatal) {
+  let handleError = function (err, message, fatal) {
     state.errMessage = err.message;
     state.stack = err.stack;
 
@@ -37,54 +42,81 @@ function reindex () {
     }
   };
 
-  storage.listContent(function (err, contentIDs, next) {
-    if (err) return handleError(err, 'Unable to list content', true);
+  let createIndex = function (callback) {
+    storage.createNewIndex(indexName, (err) => {
+      if (err) return handleError(err, 'Unable to create new index', true);
 
-    if (contentIDs.length === 0) {
-      // We've listed all of the content. Declare victory in the logs.
-      state.elapsedMs = Date.now() - state.startedTs;
-      log.info('All content re-indexed.', state);
+      callback();
+    });
+  };
 
-      exports.completedCallback(null, state);
-      return;
-    }
+  let reindexAllContent = function (callback) {
+    storage.listContent(function (err, contentIDs, next) {
+      if (err) return handleError(err, 'Unable to list content', true);
 
-    var reindexContentID = function (contentID, cb) {
-      storage.getContent(contentID, function (err, envelope) {
-        if (err) {
-          handleError(err, 'Unable to fetch envelope with ID [' + contentID + ']', false);
+      if (contentIDs.length === 0) {
+        // We've listed all of the content. Declare victory in the logs.
+        log.info('All content re-indexed.', state);
 
-          state.failedEnvelopes++;
-          state.totalEnvelopes++;
-          return cb();
-        }
+        return callback();
+      }
 
-        log.debug('Successful envelope fetch', {
-          event: 'reindex',
-          contentID: contentID
-        });
-
-        storage.indexContent(contentID, envelope, function (err) {
+      let reindexContentID = function (contentID, cb) {
+        storage.getContent(contentID, function (err, envelope) {
           if (err) {
-            handleError(err, 'Unable to index envelope with ID [' + contentID + ']', false);
+            handleError(err, 'Unable to fetch envelope with ID [' + contentID + ']', false);
+
             state.failedEnvelopes++;
             state.totalEnvelopes++;
             return cb();
           }
 
-          log.debug('Successful envelope index', {
+          log.debug('Successful envelope fetch', {
             event: 'reindex',
             contentID: contentID
           });
 
-          state.successfulEnvelopes++;
-          state.totalEnvelopes++;
-          cb();
-        });
-      });
-    };
+          storage.indexContent(contentID, envelope, indexName, function (err) {
+            if (err) {
+              handleError(err, 'Unable to index envelope with ID [' + contentID + ']', false);
+              state.failedEnvelopes++;
+              state.totalEnvelopes++;
+              return cb();
+            }
 
-    async.mapLimit(contentIDs, 20, reindexContentID, next);
+            log.debug('Successful envelope index', {
+              event: 'reindex',
+              contentID: contentID
+            });
+
+            state.successfulEnvelopes++;
+            state.totalEnvelopes++;
+            cb();
+          });
+        });
+      };
+
+      async.mapLimit(contentIDs, 20, reindexContentID, next);
+    });
+  };
+
+  let makeIndexActive = function (callback) {
+    storage.makeIndexActive(indexName, (err) => {
+      if (err) return handleError(err, 'Unable to make the index active', true);
+
+      callback(null);
+    });
+  };
+
+  async.series([
+    createIndex,
+    reindexAllContent,
+    makeIndexActive
+  ], (err) => {
+    if (err) return handleError(err, 'Top-level error', true);
+
+    state.elapsedMs = Date.now() - state.startedTs;
+    exports.completedCallback(null, state);
   });
 }
 

--- a/src/storage/connection.js
+++ b/src/storage/connection.js
@@ -135,27 +135,6 @@ function elasticInit (callback) {
   });
 
   exports.elastic = client;
-
-  var envelopeMapping = {
-    properties: {
-      title: { type: 'string', index: 'analyzed' },
-      body: { type: 'string', index: 'analyzed' },
-      keywords: { type: 'string', index: 'analyzed' },
-      categories: { type: 'string', index: 'not_analyzed' }
-    }
-  };
-
-  client.indices.create({ index: 'envelopes', ignore: 400 }, function (err) {
-    if (err) return callback(err);
-
-    client.indices.putMapping({
-      index: 'envelopes',
-      type: 'envelope',
-      body: {
-        envelope: envelopeMapping
-      }
-    }, callback);
-  });
 }
 
 exports.setup = function (callback) {

--- a/src/storage/connection.js
+++ b/src/storage/connection.js
@@ -134,7 +134,11 @@ function elasticInit (callback) {
     log: ElasticLogs
   });
 
+  logger.debug('Connected to Elasticsearch.');
+
   exports.elastic = client;
+
+  callback(null);
 }
 
 exports.setup = function (callback) {

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -113,7 +113,7 @@ exports.indexContent = function (contentID, envelope, indexName, callback) {
   }
 
   var kws = envelope.keywords || [];
-  var $ = cheerio.load(envelope.body, {
+  var $ = cheerio.load(envelope.body || '', {
     normalizeWhitespace: true
   });
 

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -23,7 +23,9 @@ var delegates = exports.delegates = [
   '_getContent',
   'deleteContent',
   'listContent',
+  'createNewIndex',
   '_indexContent',
+  'makeIndexActive',
   'queryContent',
   'unindexContent',
   'storeSHA',
@@ -98,7 +100,13 @@ exports.getContent = function (contentID, callback) {
   });
 };
 
-exports.indexContent = function (contentID, envelope, callback) {
+exports.indexContent = function (contentID, envelope, indexName, callback) {
+  // indexName is optional and defaults to the alias "envelopes-current".
+  if (!callback) {
+    callback = indexName;
+    indexName = 'envelopes-current';
+  }
+
   // Skip envelopes that have "unsearchable" set to true.
   if (envelope.unsearchable) {
     return callback(null);
@@ -116,5 +124,5 @@ exports.indexContent = function (contentID, envelope, callback) {
     categories: envelope.categories || []
   };
 
-  exports._indexContent(contentID, subset, callback);
+  exports._indexContent(contentID, subset, indexName, callback);
 };

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -101,10 +101,10 @@ exports.getContent = function (contentID, callback) {
 };
 
 exports.indexContent = function (contentID, envelope, indexName, callback) {
-  // indexName is optional and defaults to the alias "envelopes-current".
+  // indexName is optional and defaults to the alias "envelopes_current".
   if (!callback) {
     callback = indexName;
-    indexName = 'envelopes-current';
+    indexName = 'envelopes_current';
   }
 
   // Skip envelopes that have "unsearchable" set to true.

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -128,12 +128,20 @@ MemoryStorage.prototype.listContent = function (callback) {
   });
 };
 
-MemoryStorage.prototype._indexContent = function (contentID, envelope, callback) {
+MemoryStorage.prototype.createNewIndex = function (indexName, callback) {
+  callback();
+};
+
+MemoryStorage.prototype._indexContent = function (contentID, envelope, indexName, callback) {
   this.indexedEnvelopes.push({
     _id: contentID,
     _source: envelope
   });
 
+  callback();
+};
+
+MemoryStorage.prototype.makeIndexActive = function (indexName, callback) {
   callback();
 };
 

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -301,14 +301,20 @@ RemoteStorage.prototype._indexContent = function (contentID, envelope, indexName
 };
 
 RemoteStorage.prototype.makeIndexActive = function (indexName, callback) {
-  connection.elastic.updateAliases({
+  connection.elastic.indices.updateAliases({
     body: {
       actions: [
         { remove: { index: '*', alias: 'envelopes-current' } },
         { add: { index: indexName, alias: 'envelopes-current' } }
       ]
     }
-  }, callback);
+  }, (err) => {
+    if (err) return callback(err);
+
+    connection.elastic.indices.delete({
+      index: `envelopes-*,-${indexName}`
+    }, callback);
+  });
 };
 
 RemoteStorage.prototype.queryContent = function (query, categories, pageNumber, perPage, callback) {

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -301,7 +301,7 @@ RemoteStorage.prototype.queryContent = function (query, categories, pageNumber, 
   }
 
   connection.elastic.search({
-    index: 'envelopes',
+    index: 'envelopes-current',
     type: 'envelope',
     from: (pageNumber - 1) * perPage,
     size: perPage,

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -18,7 +18,30 @@ function RemoteStorage () {}
  * @description Initialize connections to external systems.
  */
 RemoteStorage.prototype.setup = function (callback) {
-  connection.setup(callback);
+  connection.setup((err) => {
+    if (err) return callback(err);
+
+    // Attempt to create the latch index. If we can, we're responsible for setting up the initial
+    // index and alias. Otherwise, another content service is on it.
+    connection.elastic.indices.create({ index: 'latch', ignore: 400 }, (err, response, status) => {
+      if (err) return callback(err);
+
+      if (status === 400) {
+        // The latch index already existed, so another service is creating the search indices.
+        // Note that there's a race condition that occurs when a service that *isn't* creating
+        // the search indices attempts to store content between the creation of the latch index
+        // and the makeIndexActive() call below in the service that is.
+        return callback(null);
+      }
+
+      let indexName = `envelopes-${Date.now()}`;
+      this.createNewIndex(indexName, (err) => {
+        if (err) return callback(err);
+
+        this.makeIndexActive(indexName, callback);
+      });
+    });
+  });
 };
 
 /**

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -319,8 +319,6 @@ RemoteStorage.prototype.makeIndexActive = function (indexName, callback) {
     }, (err, response, status) => {
       if (err) return callback(err);
 
-      console.log(require('util').inspect(response, { depth: null }));
-
       let indexNames = Object.keys(response).filter((n) => n !== indexName);
 
       async.each(indexNames, (name, cb) => {

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -28,9 +28,9 @@ describe('/reindex', function () {
   beforeEach(function () {
     indexed = {};
     realIndexContent = storage._indexContent;
-    storage._indexContent = function (contentID, envelope, callback) {
+    storage._indexContent = function (contentID, envelope, indexName, callback) {
       indexed[contentID] = envelope;
-      realIndexContent(contentID, envelope, callback);
+      realIndexContent(contentID, envelope, indexName, callback);
     };
   });
   afterEach(function () {


### PR DESCRIPTION
When reindexing content, create a new, uniquely named index. Once all content has been indexed there, update an alias to point to the new index.
- [x] Reindex content into a new index
- [x] Query through the alias rather than a specific index.
- [x] Bootstrap an initial index and point the alias to it if the alias doesn't exist on launch.
- [x] Prune unused indices after reindexing has completed.
- [x] Local testing

Fixes deconst/deconst-docs#204.
