### PR TITLE
Proxy content request failures to an upstream content service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The content service is configured by passing environment variables to the Docker
  * `MONGODB_URL`: **(required if STORAGE=remote)** MongoDB connection string, including any required authentication information.
  * `ELASTICSEARCH_HOST`: **(required if STORAGE=remote)** Elasticsearch connection string, including any required authentication information.
 
+### Proxy
+
+ * `PROXY_UPSTREAM`: *(optional)* If a URL is specified, content not found in this content store will be requested from an upstream content store API. Named assets will be accumulated from the upstream content store and this service, with named assets from this service taking precedence.
+
 ### Logging
 
  * `CONTENT_LOG_LEVEL`: *(default: `"info"`)* Optional logging level, case-insensitive. The valid levels are `TRACE`, `DEBUG`, `VERBOSE`, `INFO`, `WARN`, and `ERROR`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ content:
     ELASTICSEARCH_HOST: http://elasticsearch:9200/
     CONTENT_LOG_LEVEL:
     CONTENT_LOG_COLOR:
+    PROXY_UPSTREAM:
   volumes:
   - ".:/usr/src/app"
   command: script/inside/dev

--- a/environment.sample.sh
+++ b/environment.sample.sh
@@ -11,8 +11,10 @@ export RACKSPACE_REGION=
 export RACKSPACE_SERVICENET=
 export CONTENT_CONTAINER=
 export ASSET_CONTAINER=
-
 export ADMIN_APIKEY=
+
+# Enable to proxy failed content requests to another content service.
+# export PROXY_UPSTREAM=
 
 export CONTENT_LOG_LEVEL=debug
 export CONTENT_LOG_COLOR="true"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "lodash": "^3.8.0",
     "mongodb": "2.0.27",
     "pkgcloud": "1.1.0",
+    "request": "^2.69.0",
     "restify": "4.0.0",
+    "urljoin": "^0.1.5",
     "winston": "0.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "chai": "^3.2.0",
     "dirty-chai": "^1.2.2",
     "mocha": "^2.2.4",
+    "nock": "^7.2.2",
     "semistandard": "^7.0.3",
     "supertest": "^0.15.0"
   }

--- a/src/config.js
+++ b/src/config.js
@@ -44,6 +44,10 @@ var configuration = {
   contentLogColor: {
     env: 'CONTENT_LOG_COLOR',
     def: 'false'
+  },
+  proxyUpstream: {
+    env: 'PROXY_UPSTREAM',
+    def: null
   }
 };
 
@@ -67,7 +71,7 @@ exports.configure = function (env) {
 
     setting.value = value || setting.def;
 
-    if (!setting.value) {
+    if (setting.value === undefined) {
       missing.push(setting.env);
     }
   }

--- a/src/config.js
+++ b/src/config.js
@@ -80,7 +80,7 @@ exports.configure = function (env) {
   configuration.storage.value = configuration.storage.value.toLowerCase();
 
   // If storage is not remote, remove remote-only-mandatory settings from the missing list.
-  if (configuration.storage !== 'remote') {
+  if (configuration.storage.value !== 'remote') {
     missing = _.without(missing,
       'RACKSPACE_USERNAME', 'RACKSPACE_APIKEY', 'RACKSPACE_REGION',
       'CONTENT_CONTAINER', 'ASSET_CONTAINER',

--- a/src/routes/content.js
+++ b/src/routes/content.js
@@ -129,6 +129,21 @@ exports.retrieve = function (req, res, next) {
         return callback(err);
       }
 
+      if (response.statusCode !== 200) {
+        log.error({
+          action: 'contentretrieve',
+          contentID,
+          upstreamURL: url,
+          message: 'upstream proxy error'
+        });
+
+        let err = new Error('Upstream proxy error');
+        err.statusCode = 502;
+        err.responseBody = response.body;
+
+        return callback(err);
+      }
+
       log.debug({
         action: 'contentretrieve',
         contentID,

--- a/src/routes/content.js
+++ b/src/routes/content.js
@@ -4,6 +4,7 @@
 const async = require('async');
 const request = require('request');
 const urljoin = require('urljoin');
+const _ = require('lodash');
 const assets = require('./assets');
 const storage = require('../storage');
 const config = require('../config');
@@ -84,6 +85,7 @@ exports.retrieve = function (req, res, next) {
   });
 
   let doc = { envelope: {}, assets: {} };
+  let isUpstreamContent = false;
 
   let downloadContent = (callback) => {
     storage.getContent(contentID, (err, envelope) => {
@@ -108,7 +110,7 @@ exports.retrieve = function (req, res, next) {
       action: 'contentretrieve',
       contentID,
       upstreamURL: url,
-      message: 'making upstream request.'
+      message: 'Making upstream content request.'
     });
 
     request({ url, json: true }, (err, response, body) => {
@@ -119,7 +121,7 @@ exports.retrieve = function (req, res, next) {
           action: 'contentretrieve',
           contentID,
           upstreamURL: url,
-          message: 'content not found in upstream.'
+          message: 'Content not found in upstream.'
         });
 
         let err = new Error('Content not found');
@@ -134,7 +136,8 @@ exports.retrieve = function (req, res, next) {
           action: 'contentretrieve',
           contentID,
           upstreamURL: url,
-          message: 'upstream proxy error'
+          statusCode: response.statusCode,
+          message: 'Upstream content request error'
         });
 
         let err = new Error('Upstream proxy error');
@@ -148,9 +151,10 @@ exports.retrieve = function (req, res, next) {
         action: 'contentretrieve',
         contentID,
         upstreamURL: url,
-        message: 'proxy request successful.'
+        message: 'Upstream content request successful.'
       });
 
+      isUpstreamContent = true;
       doc = body;
       callback(null);
     });
@@ -160,7 +164,49 @@ exports.retrieve = function (req, res, next) {
     assets.enumerateNamed((err, assets) => {
       if (err) return callback(err);
 
-      doc.assets = assets;
+      // Prefer the just-fetched assets.
+      doc.assets = _.merge(doc.assets || {}, assets);
+
+      // Upstream content already has upstream assets attached. For local content, query and append
+      // upstream named assets as well.
+      if (!isUpstreamContent && config.proxyUpstream()) {
+        return injectUpstreamAssetVars(callback);
+      }
+
+      callback(null);
+    });
+  };
+
+  let injectUpstreamAssetVars = (callback) => {
+    let url = urljoin(config.proxyUpstream(), 'assets');
+    log.debug({
+      action: 'contentretrieve',
+      contentID,
+      upstreamURL: url,
+      message: 'Making upstream asset request.'
+    });
+
+    request({ url, json: true }, (err, response, upstreamAssets) => {
+      if (err) return callback(err);
+
+      if (response.statusCode !== 200) {
+        let e = new Error('Unable to retrieve upstream assets');
+        e.statusCode = 502;
+
+        return callback(e);
+      }
+
+      log.debug({
+        action: 'contentretrieve',
+        contentID,
+        upstreamURL: url,
+        upstreamAssets,
+        message: 'Upstream asset request succeeded.'
+      });
+
+      // Prefer local assets.
+      doc.assets = _.merge(upstreamAssets, doc.assets);
+
       callback(null);
     });
   };

--- a/test/helpers/before.js
+++ b/test/helpers/before.js
@@ -1,21 +1,27 @@
+'use strict';
 /*
  * Suite-global initialization that should occur before any other files are required. It's probably
  * a code smell that I have to do this.
  */
 
-var config = require('../../src/config');
+const _ = require('lodash');
+const config = require('../../src/config');
 
-function reconfigure () {
+function reconfigure (overrides) {
+  if (overrides === undefined) {
+    overrides = {};
+  }
+
   if (process.env.INTEGRATION) {
     console.log('Integration test mode active.');
 
-    config.configure(process.env);
+    config.configure(_.merge(process.env, overrides));
 
     console.log('NOTE: This will leave files uploaded in Cloud Files containers.');
     console.log('Be sure to clear these containers after:');
     console.log('[' + config.contentContainer() + '] and [' + config.assetContainer() + ']');
   } else {
-    config.configure({
+    config.configure(_.merge({
       STORAGE: 'memory',
       RACKSPACE_USERNAME: 'me',
       RACKSPACE_APIKEY: '12345',
@@ -25,10 +31,14 @@ function reconfigure () {
       ASSET_CONTAINER: 'the-asset-container',
       MONGODB_URL: 'mongodb-url',
       CONTENT_LOG_LEVEL: process.env.CONTENT_LOG_LEVEL || 'error'
-    });
+    }, overrides));
   }
 }
 
-reconfigure();
+reconfigure({});
 
-exports.reconfigure = reconfigure;
+exports.reconfigure = () => reconfigure;
+
+exports.configureWith = function (overrides) {
+  return () => reconfigure(overrides);
+};

--- a/test/helpers/before.js
+++ b/test/helpers/before.js
@@ -30,7 +30,7 @@ function reconfigure (overrides) {
       CONTENT_CONTAINER: 'the-content-container',
       ASSET_CONTAINER: 'the-asset-container',
       MONGODB_URL: 'mongodb-url',
-      CONTENT_LOG_LEVEL: process.env.CONTENT_LOG_LEVEL || 'error'
+      CONTENT_LOG_LEVEL: process.env.CONTENT_LOG_LEVEL || 'fatal'
     }, overrides));
   }
 }

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -59,7 +59,15 @@ describe('upstream', () => {
       .expect(404, done);
   });
 
-  it('reports non-404 failures from upstream as 502s');
+  it('reports non-404 failures from upstream as 502s', (done) => {
+    nock('https://upstream')
+      .get('/content/remote').reply(500, { message: 'wtf' });
+
+    request(server.create())
+      .get('/content/remote')
+      .set('Accept', 'application/json')
+      .expect(502, done);
+  });
 
   afterEach(before.reconfigure);
 });

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -47,7 +47,15 @@ describe('upstream', () => {
       .expect({ assets: {}, envelope: { body: 'remote' } }, done);
   });
 
-  it('propagates failures from the upstream content service');
+  it('propagates lookup failures from the upstream content service', (done) => {
+    nock('https://upstream')
+      .get('/content/remote').reply(404);
+
+    request(server.create())
+      .get('/content/remote')
+      .set('Accept', 'application/json')
+      .expect(404, done);
+  });
 
   afterEach(before.reconfigure);
 });

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -1,0 +1,27 @@
+'use strict';
+/* global describe it beforeEach afterEach */
+
+/*
+ * Unit tests for proxying failures to an upstream content service.
+ */
+
+const before = require('./helpers/before');
+
+const chai = require('chai');
+const dirtyChai = require('dirty-chai');
+chai.use(dirtyChai);
+
+const resetHelper = require('./helpers/reset');
+
+describe('upstream', () => {
+  beforeEach(resetHelper);
+  beforeEach(before.configureWith({
+    PROXY_UPSTREAM: 'upstream'
+  }));
+
+  it('returns present content the same');
+  it('queries the upstream content service when content is not found locally');
+  it('propagates failures from the upstream content service');
+
+  afterEach(before.reconfigure);
+});

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -11,6 +11,7 @@ const chai = require('chai');
 const dirtyChai = require('dirty-chai');
 chai.use(dirtyChai);
 
+const async = require('async');
 const nock = require('nock');
 const request = require('supertest');
 const storage = require('../src/storage');
@@ -23,30 +24,101 @@ describe('upstream', () => {
     PROXY_UPSTREAM: 'https://upstream'
   }));
 
-  // Prepopulate local storage with content.
+  // Prepopulate local storage with content and two assets.
   beforeEach((done) => storage.storeContent('local', { body: 'local' }, done));
+  beforeEach((done) => {
+    // Note to self: this is extremely awkward.
+    let assets = [
+      {
+        key: 'only-local',
+        original: 'only-local.jpg',
+        filename: 'only-local-123123.jpg',
+        chunks: [],
+        type: 'image/jpg'
+      },
+      {
+        key: 'both',
+        original: 'both.jpg',
+        filename: 'both-456456.jpg',
+        chunks: [],
+        type: 'image/jpg'
+      }
+    ];
+
+    let storeEach = (asset, cb) => {
+      storage.storeAsset(asset, (err) => {
+        if (err) return cb(err);
+
+        storage.nameAsset(asset, cb);
+      });
+    };
+
+    async.each(assets, storeEach, done);
+  });
 
   it('returns local content the same', (done) => {
+    nock('https://upstream')
+      .get('/assets').reply(200, {});
+
     request(server.create())
       .get('/content/local')
       .set('Accept', 'application/json')
       .expect(200)
       .expect('Content-Type', 'application/json')
-      .expect({ assets: {}, envelope: { body: 'local' } }, done);
+      .expect({
+        assets: {
+          'only-local': '/__local_asset__/only-local-123123.jpg',
+          'both': '/__local_asset__/both-456456.jpg'
+        },
+        envelope: { body: 'local' }
+      }, done);
   });
 
-  it('returns assets merged from local and upstream');
+  it('returns assets merged from local and upstream', (done) => {
+    nock('https://upstream')
+      .get('/assets').reply(200, {
+        'only-upstream': 'https://assets.horse/up/only-upstream-123123.jpg',
+        'both': 'https://assets.horse/up/both-321321.jpg'
+      });
+
+    request(server.create())
+      .get('/content/local')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect('Content-Type', 'application/json')
+      .expect({
+        assets: {
+          'only-upstream': 'https://assets.horse/up/only-upstream-123123.jpg',
+          'only-local': '/__local_asset__/only-local-123123.jpg',
+          'both': '/__local_asset__/both-456456.jpg'
+        },
+        envelope: { body: 'local' }
+      }, done);
+  });
 
   it('queries the upstream content service when content is not found locally', (done) => {
     nock('https://upstream')
-      .get('/content/remote').reply(200, { assets: {}, envelope: { body: 'remote' } });
+      .get('/content/remote').reply(200, {
+        assets: {
+          'only-upstream': 'https://assets.horse/up/only-upstream-123123.jpg',
+          'both': 'https://assets.horse/up/both-321321.jpg'
+        },
+        envelope: { body: 'remote' }
+      });
 
     request(server.create())
       .get('/content/remote')
       .set('Accept', 'application/json')
       .expect(200)
       .expect('Content-Type', 'application/json')
-      .expect({ assets: {}, envelope: { body: 'remote' } }, done);
+      .expect({
+        assets: {
+          'only-upstream': 'https://assets.horse/up/only-upstream-123123.jpg',
+          'only-local': '/__local_asset__/only-local-123123.jpg',
+          'both': '/__local_asset__/both-456456.jpg'
+        },
+        envelope: { body: 'remote' }
+      }, done);
   });
 
   it('propagates lookup failures from the upstream content service', (done) => {

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -35,6 +35,8 @@ describe('upstream', () => {
       .expect({ assets: {}, envelope: { body: 'local' } }, done);
   });
 
+  it('returns assets merged from local and upstream');
+
   it('queries the upstream content service when content is not found locally', (done) => {
     nock('https://upstream')
       .get('/content/remote').reply(200, { assets: {}, envelope: { body: 'remote' } });
@@ -56,6 +58,8 @@ describe('upstream', () => {
       .set('Accept', 'application/json')
       .expect(404, done);
   });
+
+  it('reports non-404 failures from upstream as 502s');
 
   afterEach(before.reconfigure);
 });

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -11,6 +11,9 @@ const chai = require('chai');
 const dirtyChai = require('dirty-chai');
 chai.use(dirtyChai);
 
+const request = require('supertest');
+const storage = require('../src/storage');
+const server = require('../src/server');
 const resetHelper = require('./helpers/reset');
 
 describe('upstream', () => {
@@ -19,7 +22,18 @@ describe('upstream', () => {
     PROXY_UPSTREAM: 'upstream'
   }));
 
-  it('returns present content the same');
+  // Prepopulate local storage with content.
+  beforeEach((done) => storage.storeContent('local', { body: 'local' }, done));
+
+  it('returns local content the same', (done) => {
+    request(server.create())
+      .get('/content/local')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect('Content-Type', 'application/json')
+      .expect({ assets: {}, envelope: { body: 'local' } }, done);
+  });
+
   it('queries the upstream content service when content is not found locally');
   it('propagates failures from the upstream content service');
 


### PR DESCRIPTION
When the optional configuration value `PROXY_UPSTREAM` is set, proxy requests for unfound content to an upstream content service's API.

Fixes #68.
