### PR TITLE
Staging mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ The content service is configured by passing environment variables to the Docker
  * `MONGODB_URL`: **(required if STORAGE=remote)** MongoDB connection string, including any required authentication information.
  * `ELASTICSEARCH_HOST`: **(required if STORAGE=remote)** Elasticsearch connection string, including any required authentication information.
 
-### Proxy
+### Staging
 
- * `PROXY_UPSTREAM`: *(optional)* If a URL is specified, content not found in this content store will be requested from an upstream content store API. Named assets will be accumulated from the upstream content store and this service, with named assets from this service taking precedence.
+ * `STAGING_MODE`: *(default: `"false"`)* Act as a staging store, to stage many revisions of content simultaneously. When staging mode is active, proxied content IDs will have their first URL path segment, the revision ID, removed when making the upstream request.
+ * `PROXY_UPSTREAM`: *(required if STAGING_MODE=true)* If a URL is specified, content not found in this content store will be requested from an upstream content store API. Named assets will be accumulated from the upstream content store and this service, with named assets from this service taking precedence.
 
 ### Logging
 

--- a/src/config.js
+++ b/src/config.js
@@ -131,6 +131,13 @@ exports.configure = function (env) {
 
     throw new Error('Invalid configuration');
   }
+
+  // Ensure that PROXY_UPSTREAM is provided if STAGING_MODE is.
+  if (configuration.stagingMode.value && !configuration.proxyUpstream.value) {
+    console.error('PROXY_UPSTREAM must be set when STAGING_MODE is enabled.');
+
+    throw new Error('Invalid configuration');
+  }
 };
 
 // Export "getter" functions for each configuration option.

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,11 @@
+'use strict';
 // Read configuration from the environment, reporting anything that's missing.
 
-var childProcess = require('child_process');
-var _ = require('lodash');
-var info = require('../package.json');
+const childProcess = require('child_process');
+const _ = require('lodash');
+const info = require('../package.json');
 
-var configuration = {
+const configuration = {
   storage: {
     env: 'STORAGE',
     def: 'remote'
@@ -48,10 +49,14 @@ var configuration = {
   proxyUpstream: {
     env: 'PROXY_UPSTREAM',
     def: null
+  },
+  stagingMode: {
+    env: 'STAGING_MODE',
+    def: 'false'
   }
 };
 
-var commit = childProcess.execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+const commit = childProcess.execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
 /**
  * @description Create a getter function for the named function.
@@ -62,12 +67,28 @@ function makeGetter (settingName) {
   };
 }
 
-exports.configure = function (env) {
-  var missing = [];
+function interpretAsBoolean (settingName) {
+  const v = configuration[settingName].value;
+  if (v !== null && v !== undefined && v !== '' && v !== 'true' && v !== 'false') {
+    console.error(`The boolean property ${configuration[settingName].env} does not have a correct value!`);
+    console.error('Boolean configuration settings must be either:');
+    console.error('* Omitted entirely');
+    console.error('* Blank');
+    console.error('* One of the strings "true" or "false"');
+    console.error(`This setting is currently: "${v}"`);
 
-  for (var name in configuration) {
-    var setting = configuration[name];
-    var value = env[setting.env];
+    throw new Error('Unrecognized boolean value');
+  }
+
+  configuration[settingName].value = v === 'true';
+}
+
+exports.configure = function (env) {
+  let missing = [];
+
+  for (let name in configuration) {
+    let setting = configuration[name];
+    let value = env[setting.env];
 
     setting.value = value || setting.def;
 
@@ -87,9 +108,10 @@ exports.configure = function (env) {
       'MONGODB_URL', 'ELASTICSEARCH_HOST');
   }
 
-  // Normalize rackspaceServiceNet and contentLogColor as booleans.
-  configuration.rackspaceServiceNet.value = (configuration.rackspaceServiceNet.value === 'true');
-  configuration.contentLogColor.value = (configuration.contentLogColor.value === 'true');
+  // Normalize rackspaceServiceNet, contentLogColor, and stagingMode as booleans.
+  interpretAsBoolean('rackspaceServiceNet');
+  interpretAsBoolean('contentLogColor');
+  interpretAsBoolean('stagingMode');
 
   if (missing.length !== 0) {
     console.error('Required configuration values are missing!');

--- a/test/config.js
+++ b/test/config.js
@@ -12,12 +12,39 @@ const dirtyChai = require('dirty-chai');
 chai.use(dirtyChai);
 const expect = chai.expect;
 
+const _ = require('lodash');
 const before = require('./helpers/before');
 const config = require('../src/config');
 
 describe('config', () => {
+  const minimum = {
+    STORAGE: 'memory',
+    ADMIN_APIKEY: '12345'
+  };
+
+  it('accepts the minimim configuration', () => {
+    config.configure(minimum);
+
+    expect(config.storage()).to.equal('memory');
+    expect(config.adminAPIKey()).to.equal('12345');
+
+    expect(config.rackspaceUsername()).to.be.undefined();
+    expect(config.rackspaceAPIKey()).to.be.undefined();
+    expect(config.rackspaceRegion()).to.be.undefined();
+    expect(config.contentContainer()).to.be.undefined();
+    expect(config.assetContainer()).to.be.undefined();
+    expect(config.mongodbURL()).to.be.undefined();
+    expect(config.elasticsearchHost()).to.be.undefined();
+
+    expect(config.rackspaceServiceNet()).to.be.false();
+    expect(config.contentLogLevel()).to.equal('info');
+    expect(config.contentLogColor()).to.be.false();
+    expect(config.proxyUpstream()).to.be.null();
+    expect(config.stagingMode()).to.be.false();
+  });
+
   it('sets variables from the environment', () => {
-    config.configure({
+    config.configure(_.defaults({
       STORAGE: 'memory',
       RACKSPACE_USERNAME: 'me',
       RACKSPACE_APIKEY: '12345',
@@ -30,7 +57,7 @@ describe('config', () => {
       CONTENT_LOG_LEVEL: 'debug',
       PROXY_UPSTREAM: 'https://upstream.horse:9000/',
       STAGING_MODE: 'true'
-    });
+    }, minimum));
 
     expect(config.storage()).to.equal('memory');
     expect(config.rackspaceUsername()).to.equal('me');
@@ -44,6 +71,14 @@ describe('config', () => {
     expect(config.contentLogLevel()).to.equal('debug');
     expect(config.proxyUpstream()).to.equal('https://upstream.horse:9000/');
     expect(config.stagingMode()).to.equal(true);
+  });
+
+  it('requires PROXY_UPSTREAM when STAGING_MODE is active', () => {
+    expect(() => {
+      config.configure(_.defaults({
+        STAGING_MODE: 'true'
+      }, minimum));
+    }).to.throw(Error);
   });
 
   afterEach(before.reconfigure);

--- a/test/config.js
+++ b/test/config.js
@@ -1,3 +1,4 @@
+'use strict';
 /* global describe it afterEach */
 
 /*
@@ -6,17 +7,16 @@
 
 require('./helpers/before');
 
-var chai = require('chai');
-var dirtyChai = require('dirty-chai');
-
+const chai = require('chai');
+const dirtyChai = require('dirty-chai');
 chai.use(dirtyChai);
-var expect = chai.expect;
+const expect = chai.expect;
 
-var before = require('./helpers/before');
-var config = require('../src/config');
+const before = require('./helpers/before');
+const config = require('../src/config');
 
-describe('config', function () {
-  it('sets variables from the environment', function () {
+describe('config', () => {
+  it('sets variables from the environment', () => {
     config.configure({
       STORAGE: 'memory',
       RACKSPACE_USERNAME: 'me',
@@ -27,7 +27,8 @@ describe('config', function () {
       CONTENT_CONTAINER: 'the-content-container',
       ASSET_CONTAINER: 'the-asset-container',
       MONGODB_URL: 'mongodb-url',
-      CONTENT_LOG_LEVEL: 'debug'
+      CONTENT_LOG_LEVEL: 'debug',
+      PROXY_UPSTREAM: 'https://upstream.horse:9000/'
     });
 
     expect(config.storage()).to.equal('memory');
@@ -40,6 +41,7 @@ describe('config', function () {
     expect(config.assetContainer()).to.equal('the-asset-container');
     expect(config.mongodbURL()).to.equal('mongodb-url');
     expect(config.contentLogLevel()).to.equal('debug');
+    expect(config.proxyUpstream()).to.equal('https://upstream.horse:9000/');
   });
 
   afterEach(before.reconfigure);

--- a/test/config.js
+++ b/test/config.js
@@ -28,7 +28,8 @@ describe('config', () => {
       ASSET_CONTAINER: 'the-asset-container',
       MONGODB_URL: 'mongodb-url',
       CONTENT_LOG_LEVEL: 'debug',
-      PROXY_UPSTREAM: 'https://upstream.horse:9000/'
+      PROXY_UPSTREAM: 'https://upstream.horse:9000/',
+      STAGING_MODE: 'true'
     });
 
     expect(config.storage()).to.equal('memory');
@@ -42,6 +43,7 @@ describe('config', () => {
     expect(config.mongodbURL()).to.equal('mongodb-url');
     expect(config.contentLogLevel()).to.equal('debug');
     expect(config.proxyUpstream()).to.equal('https://upstream.horse:9000/');
+    expect(config.stagingMode()).to.equal(true);
   });
 
   afterEach(before.reconfigure);

--- a/test/helpers/before.js
+++ b/test/helpers/before.js
@@ -37,7 +37,7 @@ function reconfigure (overrides) {
 
 reconfigure({});
 
-exports.reconfigure = () => reconfigure;
+exports.reconfigure = () => reconfigure({});
 
 exports.configureWith = function (overrides) {
   return () => reconfigure(overrides);


### PR DESCRIPTION
When `STAGING_MODE` is set to `"true"`, content ID requests that are retried upstream should have their first path segment (which, by convention, will be the revision ID of a staged revision) removed before the proxying happens.
- [x] Add and test the `STAGING_MODE` configuration parameter.
- [x] Parse the content ID as a URL, snip the path segment, and re-assemble it.
- [x] README update to explain the new configuration option.

Fixes #69.
