### PR TITLE
Add the MONGODB_PREFIX setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The content service is configured by passing environment variables to the Docker
  * `CONTENT_CONTAINER`: **(required if STORAGE=remote)** Container name to use for the stored metadata envelopes.
  * `ASSET_CONTAINER`: **(required if STORAGE=remote)** Container name to use for published assets.
  * `MONGODB_URL`: **(required if STORAGE=remote)** MongoDB connection string, including any required authentication information.
+ * `MONGODB_PREFIX`: **(default: `""`)** Prefix used to partition MongoDB collection names from other services using the same MongoDB database.
  * `ELASTICSEARCH_HOST`: **(required if STORAGE=remote)** Elasticsearch connection string, including any required authentication information.
 
 ### Staging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,13 @@ content:
     ADMIN_APIKEY:
     CONTENT_CONTAINER:
     ASSET_CONTAINER:
+    MONGODB_PREFIX:
     MONGODB_URL: mongodb://mongo:27017/content
     ELASTICSEARCH_HOST: http://elasticsearch:9200/
     CONTENT_LOG_LEVEL:
     CONTENT_LOG_COLOR:
     PROXY_UPSTREAM:
+    STAGING_MODE:
   volumes:
   - ".:/usr/src/app"
   command: script/inside/dev

--- a/src/config.js
+++ b/src/config.js
@@ -35,6 +35,10 @@ const configuration = {
   mongodbURL: {
     env: 'MONGODB_URL'
   },
+  mongodbPrefix: {
+    env: 'MONGODB_PREFIX',
+    def: ''
+  },
   elasticsearchHost: {
     env: 'ELASTICSEARCH_HOST'
   },

--- a/src/routes/content.js
+++ b/src/routes/content.js
@@ -105,7 +105,7 @@ exports.retrieve = function (req, res, next) {
   };
 
   let downloadUpstreamContent = (callback) => {
-    let upstreamContentID = removeRevisionID(contentID);
+    let upstreamContentID = config.stagingMode() ? removeRevisionID(contentID) : contentID;
     let url = urljoin(config.proxyUpstream(), 'content', encodeURIComponent(upstreamContentID));
 
     log.debug({

--- a/src/storage/connection.js
+++ b/src/storage/connection.js
@@ -56,35 +56,8 @@ function mongoInit (callback) {
     if (err) return callback(err);
 
     logger.debug('Connected to MongoDB database at [' + config.mongodbURL() + '].');
-
     exports.db = db;
-
-    var envelopes = db.collection('envelopes');
-
-    // Create indices on collections as necessary.
-    async.parallel([
-      function (callback) {
-        envelopes.createIndex('tags', {
-          sparse: true
-        }, callback);
-      },
-      function (callback) {
-        envelopes.createIndex('categories', {
-          sparse: true
-        }, callback);
-      },
-      function (callback) {
-        envelopes.createIndex('contentID', {
-          unique: true
-        }, callback);
-      }
-    ], function (err, db) {
-      if (err) return callback(err);
-
-      logger.debug('All indices created.');
-
-      callback(null);
-    });
+    callback(null);
   });
 }
 

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -400,7 +400,7 @@ RemoteStorage.prototype.getSHA = function (callback) {
 };
 
 function mongoCollection (name) {
-  return connection.db.collection(config.mongodbPrefix + name);
+  return connection.db.collection(config.mongodbPrefix() + name);
 }
 
 module.exports = {

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -91,7 +91,7 @@ RemoteStorage.prototype.storeAsset = function (asset, callback) {
  * same name if present.
  */
 RemoteStorage.prototype.nameAsset = function (asset, callback) {
-  connection.db.collection('layoutAssets').updateOne({
+  mongoCollection('layoutAssets').updateOne({
     key: asset.key
   }, {
     $set: {
@@ -111,7 +111,7 @@ RemoteStorage.prototype.nameAsset = function (asset, callback) {
  * @description List all assets that have been persisted in Mongo with nameAsset.
  */
 RemoteStorage.prototype.findNamedAssets = function (callback) {
-  connection.db.collection('layoutAssets').find().toArray(callback);
+  mongoCollection('layoutAssets').find().toArray(callback);
 };
 
 /**
@@ -154,14 +154,14 @@ RemoteStorage.prototype.getAsset = function (filename, callback) {
  * @description Store a newly generated API key in the keys collection.
  */
 RemoteStorage.prototype.storeKey = function (key, callback) {
-  connection.db.collection('apiKeys').insertOne(key, callback);
+  mongoCollection('apiKeys').insertOne(key, callback);
 };
 
 /**
  * @description Forget a previously stored API key by key value.
  */
 RemoteStorage.prototype.deleteKey = function (apikey, callback) {
-  connection.db.collection('apiKeys').deleteOne({
+  mongoCollection('apiKeys').deleteOne({
     apikey: apikey
   }, callback);
 };
@@ -171,7 +171,7 @@ RemoteStorage.prototype.deleteKey = function (apikey, callback) {
  *   return either zero or one results, but you never know.
  */
 RemoteStorage.prototype.findKeys = function (apikey, callback) {
-  connection.db.collection('apiKeys').find({
+  mongoCollection('apiKeys').find({
     apikey: apikey
   }).toArray(callback);
 };
@@ -373,7 +373,7 @@ RemoteStorage.prototype.unindexContent = function (contentID, callback) {
 };
 
 RemoteStorage.prototype.storeSHA = function (sha, callback) {
-  connection.db.collection('sha').updateOne({
+  mongoCollection('sha').updateOne({
     key: 'controlRepository'
   }, {
     $set: {
@@ -386,7 +386,7 @@ RemoteStorage.prototype.storeSHA = function (sha, callback) {
 };
 
 RemoteStorage.prototype.getSHA = function (callback) {
-  connection.db.collection('sha').findOne({key: 'controlRepository'}, function (err, doc) {
+  mongoCollection('sha').findOne({key: 'controlRepository'}, function (err, doc) {
     if (err) {
       return callback(err);
     }
@@ -398,6 +398,10 @@ RemoteStorage.prototype.getSHA = function (callback) {
     callback(null, doc.sha);
   });
 };
+
+function mongoCollection (name) {
+  return connection.db.collection(config.mongodbPrefix + name);
+}
 
 module.exports = {
   RemoteStorage: RemoteStorage

--- a/test/config.js
+++ b/test/config.js
@@ -41,6 +41,7 @@ describe('config', () => {
     expect(config.contentLogColor()).to.be.false();
     expect(config.proxyUpstream()).to.be.null();
     expect(config.stagingMode()).to.be.false();
+    expect(config.mongodbPrefix()).to.equal('');
   });
 
   it('sets variables from the environment', () => {
@@ -54,6 +55,7 @@ describe('config', () => {
       CONTENT_CONTAINER: 'the-content-container',
       ASSET_CONTAINER: 'the-asset-container',
       MONGODB_URL: 'mongodb-url',
+      MONGODB_PREFIX: 'foo-',
       CONTENT_LOG_LEVEL: 'debug',
       PROXY_UPSTREAM: 'https://upstream.horse:9000/',
       STAGING_MODE: 'true'
@@ -68,6 +70,7 @@ describe('config', () => {
     expect(config.contentContainer()).to.equal('the-content-container');
     expect(config.assetContainer()).to.equal('the-asset-container');
     expect(config.mongodbURL()).to.equal('mongodb-url');
+    expect(config.mongodbPrefix()).to.equal('foo-');
     expect(config.contentLogLevel()).to.equal('debug');
     expect(config.proxyUpstream()).to.equal('https://upstream.horse:9000/');
     expect(config.stagingMode()).to.equal(true);


### PR DESCRIPTION
Partition MongoDB collections by optionally setting a prefix on the collection names. Hacky but it'll do for now.

Fixes #74.
