### PR TITLE
Make the Elasticsearch connection optional.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -40,7 +40,8 @@ const configuration = {
     def: ''
   },
   elasticsearchHost: {
-    env: 'ELASTICSEARCH_HOST'
+    env: 'ELASTICSEARCH_HOST',
+    def: null
   },
   contentLogLevel: {
     env: 'CONTENT_LOG_LEVEL',
@@ -109,7 +110,7 @@ exports.configure = function (env) {
     missing = _.without(missing,
       'RACKSPACE_USERNAME', 'RACKSPACE_APIKEY', 'RACKSPACE_REGION',
       'CONTENT_CONTAINER', 'ASSET_CONTAINER',
-      'MONGODB_URL', 'ELASTICSEARCH_HOST');
+      'MONGODB_URL');
   }
 
   // Normalize rackspaceServiceNet, contentLogColor, and stagingMode as booleans.

--- a/src/storage/connection.js
+++ b/src/storage/connection.js
@@ -108,6 +108,12 @@ function ElasticLogs (config) {
  * Elasticsearch client as "elastic".
  */
 function elasticInit (callback) {
+  if (!config.elasticsearcHost()) {
+    logger.info('Omitting Elasticsearch connection. Search will be unavailable.');
+
+    return callback(null);
+  }
+
   var client = new elasticsearch.Client({
     host: config.elasticsearchHost(),
     apiVersion: '1.7',

--- a/src/storage/connection.js
+++ b/src/storage/connection.js
@@ -108,7 +108,7 @@ function ElasticLogs (config) {
  * Elasticsearch client as "elastic".
  */
 function elasticInit (callback) {
-  if (!config.elasticsearcHost()) {
+  if (!config.elasticsearchHost()) {
     logger.info('Omitting Elasticsearch connection. Search will be unavailable.');
 
     return callback(null);

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -22,6 +22,8 @@ RemoteStorage.prototype.setup = function (callback) {
   connection.setup((err) => {
     if (err) return callback(err);
 
+    if (!connection.elastic) return callback(null);
+
     // Attempt to create the latch index. If we can, we're responsible for setting up the initial
     // index and alias. Otherwise, another content service is on it.
     connection.elastic.indices.create({ index: 'latch', ignore: 400 }, (err, response, status) => {
@@ -270,6 +272,8 @@ RemoteStorage.prototype.listContent = function (callback) {
 };
 
 RemoteStorage.prototype.createNewIndex = function (indexName, callback) {
+  if (!connection.elastic) return callback(null);
+
   let envelopeMapping = {
     properties: {
       title: { type: 'string', index: 'analyzed' },
@@ -293,6 +297,8 @@ RemoteStorage.prototype.createNewIndex = function (indexName, callback) {
 };
 
 RemoteStorage.prototype._indexContent = function (contentID, envelope, indexName, callback) {
+  if (!connection.elastic) return callback(null);
+
   connection.elastic.index({
     index: indexName,
     type: 'envelope',
@@ -302,6 +308,8 @@ RemoteStorage.prototype._indexContent = function (contentID, envelope, indexName
 };
 
 RemoteStorage.prototype.makeIndexActive = function (indexName, callback) {
+  if (!connection.elastic) return callback(null);
+
   connection.elastic.indices.updateAliases({
     body: {
       actions: [
@@ -329,6 +337,15 @@ RemoteStorage.prototype.makeIndexActive = function (indexName, callback) {
 };
 
 RemoteStorage.prototype.queryContent = function (query, categories, pageNumber, perPage, callback) {
+  if (!connection.elastic) {
+    return callback(null, {
+      hits: {
+        hits: [],
+        total: 0
+      }
+    });
+  }
+
   var q = {};
 
   if (!categories) {
@@ -358,6 +375,8 @@ RemoteStorage.prototype.queryContent = function (query, categories, pageNumber, 
 };
 
 RemoteStorage.prototype.unindexContent = function (contentID, callback) {
+  if (!connection.elastic) return callback(null);
+
   connection.elastic.delete({
     index: 'envelopes_current',
     type: 'envelope',

--- a/test/config.js
+++ b/test/config.js
@@ -34,9 +34,9 @@ describe('config', () => {
     expect(config.contentContainer()).to.be.undefined();
     expect(config.assetContainer()).to.be.undefined();
     expect(config.mongodbURL()).to.be.undefined();
-    expect(config.elasticsearchHost()).to.be.undefined();
 
     expect(config.rackspaceServiceNet()).to.be.false();
+    expect(config.elasticsearchHost()).to.be.null();
     expect(config.contentLogLevel()).to.equal('info');
     expect(config.contentLogColor()).to.be.false();
     expect(config.proxyUpstream()).to.be.null();
@@ -56,6 +56,7 @@ describe('config', () => {
       ASSET_CONTAINER: 'the-asset-container',
       MONGODB_URL: 'mongodb-url',
       MONGODB_PREFIX: 'foo-',
+      ELASTICSEARCH_HOST: 'https://elasticsearch:9200/',
       CONTENT_LOG_LEVEL: 'debug',
       PROXY_UPSTREAM: 'https://upstream.horse:9000/',
       STAGING_MODE: 'true'
@@ -71,6 +72,7 @@ describe('config', () => {
     expect(config.assetContainer()).to.equal('the-asset-container');
     expect(config.mongodbURL()).to.equal('mongodb-url');
     expect(config.mongodbPrefix()).to.equal('foo-');
+    expect(config.elasticsearchHost()).to.equal('https://elasticsearch:9200/');
     expect(config.contentLogLevel()).to.equal('debug');
     expect(config.proxyUpstream()).to.equal('https://upstream.horse:9000/');
     expect(config.stagingMode()).to.equal(true);


### PR DESCRIPTION
If no `ELASTICSEARCH_HOST` configuration option is provided, log it, don't attempt to connect to Elasticsearch, and stub out search-related storage calls.

Fixes #79.
