### PR TITLE
Proxy /control directly to upstream.

### DIFF
--- a/src/routes/control.js
+++ b/src/routes/control.js
@@ -1,12 +1,13 @@
+'use strict';
 // Manage the SHA of the latest control repository commit.
 
-var restify = require('restify');
-var request = require('request');
-var urljoin = require('urljoin');
+const restify = require('restify');
+const request = require('request');
+const urljoin = require('urljoin');
 
-var config = require('../config');
-var storage = require('../storage');
-var log = require('../logging').getLogger();
+const config = require('../config');
+const storage = require('../storage');
+const logger = require('../logging').getLogger();
 
 exports.store = function (req, res, next) {
   if (req.params.sha === undefined) {
@@ -17,12 +18,12 @@ exports.store = function (req, res, next) {
     return next(new restify.InvalidContentError('Not a valid "sha"'));
   }
 
-  storage.storeSHA(req.params.sha, function (err) {
+  storage.storeSHA(req.params.sha, (err) => {
     next.ifError(err);
 
     res.send(204);
 
-    log.info('Stored control repository SHA', {
+    logger.info('Stored control repository SHA', {
       sha: req.params.sha
     });
     next();
@@ -35,7 +36,7 @@ exports.retrieve = function (req, res, next) {
     return next();
   }
 
-  storage.getSHA(function (err, sha) {
+  storage.getSHA((err, sha) => {
     next.ifError(err);
 
     res.json(200, {sha: sha});

--- a/src/routes/control.js
+++ b/src/routes/control.js
@@ -1,7 +1,10 @@
 // Manage the SHA of the latest control repository commit.
 
 var restify = require('restify');
+var request = require('request');
+var urljoin = require('urljoin');
 
+var config = require('../config');
 var storage = require('../storage');
 var log = require('../logging').getLogger();
 
@@ -27,6 +30,11 @@ exports.store = function (req, res, next) {
 };
 
 exports.retrieve = function (req, res, next) {
+  if (config.proxyUpstream()) {
+    request(urljoin(config.proxyUpstream(), 'control')).pipe(res);
+    return next();
+  }
+
   storage.getSHA(function (err, sha) {
     next.ifError(err);
 

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -142,7 +142,16 @@ describe('upstream', () => {
   });
 
   describe('control SHA', () => {
-    it('proxies /control directly to upstream');
+    it('proxies /control directly to upstream', (done) => {
+      nock('https://upstream')
+        .get('/control').reply(200, { sha: '12341234' });
+
+      request(server.create())
+        .get('/control')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .expect({ sha: '12341234' }, done);
+    });
   });
 
   afterEach(before.reconfigure);

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -141,5 +141,9 @@ describe('upstream', () => {
     });
   });
 
+  describe('control SHA', () => {
+    it('proxies /control directly to upstream');
+  });
+
   afterEach(before.reconfigure);
 });


### PR DESCRIPTION
This is the laziest way to keep staging's control repository up to date with production.

Fixes #82.
