### PR TITLE
Omit stack traces from routine 404s

### DIFF
--- a/src/routes/content.js
+++ b/src/routes/content.js
@@ -167,6 +167,7 @@ exports.retrieve = function (req, res, next) {
       var message = 'Unable to retrieve content.';
       if (err.statusCode && err.statusCode === 404) {
         message = `No content for ID [${contentID}]`;
+        err.stack = null;
       }
 
       log.error({


### PR DESCRIPTION
I'd really like to be able to filter for `stack:"*"` in Kibana to see crashes, but it ends up being cluttered with 404s instead. The stack trace isn't very useful in that case, anyway, so I'm taking it out.
