### PR TITLE
Return a fallback excerpt from envelopes that only match in their title

### DIFF
--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -53,7 +53,7 @@ exports.query = function (req, res, next) {
         title: each._source.title
       };
 
-      if (each.highlight.body.length > 0) {
+      if (each.highlight && each.highlight.body.length > 0) {
         transformed.excerpt = each.highlight.body[0];
       } else {
         transformed.excerpt = each._source.body.substr(0, 150);

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -159,13 +159,12 @@ MemoryStorage.prototype.queryContent = function (query, categories, pageNumber, 
   }).map(function (entry) {
     // Populate "highlights" as just the regexp matches, surrounded by <em> tags.
     var m = rx.exec(entry._source.body);
-    var highlight = [];
 
     if (m !== null) {
-      highlight.push('...<em>' + entry._source.body.substr(m.index, m[0].length) + '</em>...');
+      var highlight = [`...<em>${m[0]}</em>...`];
+      entry.highlight = {body: highlight};
     }
 
-    entry.highlight = {body: highlight};
     return entry;
   });
 

--- a/test/search.js
+++ b/test/search.js
@@ -46,7 +46,21 @@ describe('/search', function () {
       }, done);
   });
 
-  it('returns an empty excerpt when a match is only in the title');
+  it('returns an empty excerpt when a match is only in the title', function (done) {
+    request(server.create())
+      .get('/search?q=second')
+      .expect(200)
+      .expect({
+        total: 1,
+        results: [
+          {
+            contentID: 'foo/bbb',
+            title: 'second',
+            excerpt: ''
+          }
+        ]
+      }, done);
+  });
 
   it('responds with a 409 if no query is provided', function (done) {
     request(server.create())

--- a/test/search.js
+++ b/test/search.js
@@ -46,7 +46,7 @@ describe('/search', function () {
       }, done);
   });
 
-  it('returns an empty excerpt when a match is only in the title', function (done) {
+  it('returns a body excerpt when a match is only in the title', function (done) {
     request(server.create())
       .get('/search?q=second')
       .expect(200)
@@ -56,7 +56,7 @@ describe('/search', function () {
           {
             contentID: 'foo/bbb',
             title: 'second',
-            excerpt: ''
+            excerpt: 'all bbb'
           }
         ]
       }, done);

--- a/test/search.js
+++ b/test/search.js
@@ -46,6 +46,8 @@ describe('/search', function () {
       }, done);
   });
 
+  it('returns an empty excerpt when a match is only in the title');
+
   it('responds with a 409 if no query is provided', function (done) {
     request(server.create())
       .get('/search')


### PR DESCRIPTION
When an envelope only matches an Elasticsearch query in its title or keywords, there's no excerpt in the search result. Return a fallback excerpt of the first so many body characters rather than throwing an exception.

Fixes #88.
