### PR TITLE
Wait for Elasticsearch on launch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,36 +1,34 @@
----
-elasticsearch:
-  image: elasticsearch:1.7
-  ports:
-  - "9200:9200"
-mongo:
-  image: mongo:2.6
-content:
-  build: .
-  ports:
-  - "9000:8080"
-  links:
-  - "mongo:mongo"
-  - "elasticsearch:elasticsearch"
-  environment:
-    ACTION:
-    INTEGRATION:
-    NODE_ENV:
-    STORAGE:
-    RACKSPACE_USERNAME:
-    RACKSPACE_APIKEY:
-    RACKSPACE_REGION:
-    RACKSPACE_SERVICENET:
-    ADMIN_APIKEY:
-    CONTENT_CONTAINER:
-    ASSET_CONTAINER:
-    MONGODB_PREFIX:
-    MONGODB_URL: mongodb://mongo:27017/content
-    ELASTICSEARCH_HOST: http://elasticsearch:9200/
-    CONTENT_LOG_LEVEL:
-    CONTENT_LOG_COLOR:
-    PROXY_UPSTREAM:
-    STAGING_MODE:
-  volumes:
-  - ".:/usr/src/app"
-  command: script/inside/dev
+version: '2'
+services:
+  elasticsearch:
+    image: elasticsearch:1.7
+    ports:
+    - "9200:9200"
+  mongo:
+    image: mongo:2.6
+  content:
+    build: .
+    ports:
+    - "9000:8080"
+    environment:
+      ACTION:
+      INTEGRATION:
+      NODE_ENV:
+      STORAGE:
+      RACKSPACE_USERNAME:
+      RACKSPACE_APIKEY:
+      RACKSPACE_REGION:
+      RACKSPACE_SERVICENET:
+      ADMIN_APIKEY:
+      CONTENT_CONTAINER:
+      ASSET_CONTAINER:
+      MONGODB_PREFIX:
+      MONGODB_URL: mongodb://mongo:27017/content
+      ELASTICSEARCH_HOST: http://elasticsearch:9200/
+      CONTENT_LOG_LEVEL:
+      CONTENT_LOG_COLOR:
+      PROXY_UPSTREAM:
+      STAGING_MODE:
+    volumes:
+    - ".:/usr/src/app"
+    command: script/inside/dev

--- a/src/storage/connection.js
+++ b/src/storage/connection.js
@@ -122,11 +122,23 @@ function elasticInit (callback) {
     maxRetries: Infinity
   });
 
-  logger.debug('Connected to Elasticsearch.');
+  client.ping(function (err) {
+    if (err) {
+      logger.warn('Unable to connect to Elasticsearch. Retrying in five seconds.', {
+        elasticsearchHost: config.elasticsearchHost(),
+        err: err.message
+      });
 
-  exports.elastic = client;
+      setTimeout(() => elasticInit(callback), 5000);
+      return;
+    }
 
-  callback(null);
+    logger.debug('Connected to Elasticsearch.');
+
+    exports.elastic = client;
+
+    callback(null);
+  });
 }
 
 exports.setup = function (callback) {


### PR DESCRIPTION
If Elasticsearch isn't available at launch, poll until it is like we do for Mongo.

Fixes #78.
