### PR TITLE
Saner Authorization headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,17 @@ Both Cloud Files containers will be created and configured on application launch
 ### Authorization
 
 Endpoints that require authorization *must* be accompanied by a valid API key. Set the API key in
-an `Authorization` header.
+an `Authorization` header with a scheme of "deconst".
 
 ```
 PUT /content/https%3A%2F%2Fgithub.com%2Fsomeuser%2Fsomerepo%2Fsomeid
-Authorization: deconst apikey="12345"
+Authorization: deconst 12345
+```
+
+Or:
+
+```bash
+curl -H 'Authorization: deconst 12345' # ...
 ```
 
 Valid API keys include:

--- a/test/helpers/auth.js
+++ b/test/helpers/auth.js
@@ -2,11 +2,11 @@
 
 exports.APIKEY_ADMIN = process.env.ADMIN_APIKEY || '12345';
 
-exports.AUTH_ADMIN = 'deconst apikey="' + exports.APIKEY_ADMIN + '"';
+exports.AUTH_ADMIN = 'deconst ' + exports.APIKEY_ADMIN;
 
 exports.APIKEY_USER = '54321';
 
-exports.AUTH_USER = 'deconst apikey="' + exports.APIKEY_USER + '"';
+exports.AUTH_USER = 'deconst ' + exports.APIKEY_USER;
 
 /**
  * @description Test helper to ensure that a route fails if no API key is given.


### PR DESCRIPTION
Just touching up something that's been annoying me for a while. Rather than require the odd Authorization header:

``` bash
curl -H 'Authorization deconst apikey="..."'
```

Just pass the API key as the header value:

``` bash
curl -H 'Authorization deconst ...'
```

To avoid breaking everything: recognize both forms for some period of time, then log warnings when the old form is encountered, then :hocho: once the warning hasn't appeared for some period of time.

This was a @ktbartholomew eyebrow-raiser way back when he started on the project. I think I found some RFC about Authorization headers that described this format, but nobody uses it so ¯_(ツ)_/¯
