### PR TITLE
Don't prematurely end the asset stream.

### DIFF
--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -92,8 +92,6 @@ RemoteStorage.prototype.storeAsset = function (stream, filename, contentType, ca
   });
 
   stream.pipe(up);
-
-  up.end();
 };
 
 /**


### PR DESCRIPTION
Calling `.end()` on the asset stream before the pipe completes causes Cloud Files to receive empty assets. Oops.
