### PR TITLE
Check fingerprints of assets and envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,41 @@ An HTTP status of 500 is returned if there are problems accepting one or more en
 
 Note that the successful envelopes *were* accepted and are live.
 
+### `GET /checkcontent`
+
+Perform a bulk query to determine which envelopes need to be updated and which are unchanged.
+
+*Request*
+
+Attach a body to the GET request containing a JSON object mapping content IDs to SHA-256 checksums. Generate each checksums from a compact (whitespace-less) JSON representation with sorted object keys.
+
+```json
+{
+  "https://github.com/org/repo": "b1b6e4c544880769b42bdbf7f6338cba3db78cf734424af20e5c4d30251a984c",
+  "https://github.com/org/repo/somepath": "0ff459af6d050d72d642eeb3a1ea5a8a93fd518993ac56711bd86a7e49b95191"
+}
+```
+
+*Response (successful)*
+
+The response will have a 200 status and a response body containing the queried content IDs and a boolean value of:
+
+* `true` if the envelope with that ID is already present and its checksum matches, or
+* `false` if the envelope is either missing entirely or its checksum differs.
+
+The envelope that's queried for a fingerprint match is the envelope that would be rendered for a `GET /content/:id` request against this endpoint. In staging mode, this means that an envelope that's present in the local store with a different checksum will return `false` even if the upstream content service has that envelope with a matching checksum.
+
+```json
+{
+  "https://github.com/org/repo": true,
+  "https://github.com/org/repo/somepath": false
+}
+```
+
+*Response (unsuccessful)*
+
+A status of 500 indicates that an internal storage error occurred. A status of 502 indicates that the content store is configured to proxy to an upstream service, but it couldn't be reached.
+
 ### `POST /assets[?named=true]`
 
 **(Authorization required: any user)**

--- a/README.md
+++ b/README.md
@@ -321,6 +321,41 @@ Returns an HTTP status of 200 and a map containing the tarball's path to each as
 
 If the uploaded file is not a valid tarball, an HTTP status of 400 will be returned. If there are problems performing the batch upload an HTTP status of 500 will be returned.
 
+### `GET /checkassets`
+
+Perform a bulk query to determine which assets need to be uploaded and which are already present.
+
+*Request*
+
+Attach a body to the GET request containing a JSON object mapping asset filenames to SHA-256 checksums.
+
+```json
+{
+  "header.jpg": "08facdf9cdab2065dd76d0c50c20d93141c1e2be8a1224782458b0f41ad04eee",
+  "local/path/style.min.css": "5746528f57f4c571bcbcdd7334b4396277877488bff0207603d7fb829fa7f854"
+}
+```
+
+*Response (successful)*
+
+The response will have a 200 status and a response body mapping the queried paths to:
+
+* The known asset's public CDN URL if an asset with that filename and checksum is already present, or
+* `null` if no such asset exists.
+
+In staging mode, the upstream content store will be queried for any assets that are not present locally.
+
+```json
+{
+  "header.jpg": "https://my.awesome.cdn/public/header-08facdf9cdab2065dd76d0c50c20d93141c1e2be8a1224782458b0f41ad04eee.jpg",
+  "local/path/style.min.css": null
+}
+```
+
+*Response (unsuccessful)*
+
+A status of 500 indicates that an internal storage error occurred. A status of 502 indicates that the content store is configured to proxy to an upstream service, but it couldn't be reached.
+
 ### `POST /keys?named=:name`
 
 **(Authorization required: admin only)**

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "async": "2.0.0-rc.2",
     "cheerio": "^0.19.0",
     "elasticsearch": "^9.0.2",
+    "json-stable-stringify": "^1.0.1",
     "lodash": "^3.8.0",
     "mongodb": "2.0.27",
     "pkgcloud": "1.1.0",

--- a/src/routes/assets/check.js
+++ b/src/routes/assets/check.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Test for the existance of assets
+
+const async = require('async');
+const storage = require('../../storage');
+const fingerprinted = require('./store').fingerprinted;
+
+/**
+ * @description Accept an object mapping asset filenames to SHA-256 checksums of their content.
+ * Return an object mapping each filename to its public CDN URL (if it exists) or null (if it
+ * doesn't.)
+ */
+exports.handler = function (req, res, next) {
+  req.logger.debug('Request body', { body: req.body });
+
+  const assetMap = req.body;
+  const assetFilenames = Object.keys(assetMap);
+  const results = {};
+
+  req.logger.debug('Checking asset existence', { assetCount: assetFilenames.length });
+
+  const assetCheck = (assetFilename, cb) => {
+    const fingerprint = assetMap[assetFilename];
+    const internalName = fingerprinted(assetFilename, fingerprint);
+
+    storage.assetExists(internalName, (err, exists) => {
+      if (err) {
+        req.logger.reportError('Unable to check for asset', err, {
+          payload: { assetFilename, fingerprint }
+        });
+
+        results[assetFilename] = null;
+        return cb(null);
+      }
+
+      if (exists) {
+        results[assetFilename] = storage.assetURLPrefix() + internalName;
+      } else {
+        results[assetFilename] = null;
+      }
+
+      cb(null);
+    });
+  };
+
+  async.each(assetFilenames, assetCheck, (err) => {
+    if (err) {
+      req.logger.reportError('Unable to check asset existence', err);
+      return next(err);
+    }
+
+    res.send(200, results);
+    next();
+  });
+};

--- a/src/routes/assets/check.js
+++ b/src/routes/assets/check.js
@@ -67,11 +67,15 @@ exports.handler = function (req, res, next) {
         if (publicURL === null) subquery[pathname] = query[pathname];
       });
 
-      checkUpstream(req.logger, subquery, (err, subresults) => {
-        if (err) return finish(err);
+      if (Object.keys(subquery).length > 0) {
+        checkUpstream(req.logger, subquery, (err, subresults) => {
+          if (err) return finish(err);
 
-        finish(null, _.assign(localResults, subresults));
-      });
+          finish(null, _.assign(localResults, subresults));
+        });
+      } else {
+        finish(null, localResults);
+      }
     } else {
       finish(null, localResults);
     }

--- a/src/routes/assets/index.js
+++ b/src/routes/assets/index.js
@@ -3,4 +3,5 @@
 exports.store = require('./store').handler;
 exports.bulk = require('./bulk').handler;
 exports.retrieve = require('./retrieve').handler;
+exports.check = require('./check').handler;
 exports.list = require('./list').handler;

--- a/src/routes/assets/store.js
+++ b/src/routes/assets/store.js
@@ -86,12 +86,7 @@ const makeAssetFingerprinter = function (logger, asset) {
     stream.on('error', callback);
 
     stream.on('end', () => {
-      const digest = sha256sum.digest('hex');
-      const ext = path.extname(asset.filename);
-      const basename = path.basename(asset.filename, ext);
-      const fingerprinted = `${basename}-${digest}${ext}`;
-
-      asset.fingerprinted = fingerprinted;
+      asset.fingerprinted = fingerprinted(asset.filename, sha256sum.digest('hex'));
 
       logger.debug('Asset fingerprinted.', {
         assetName: asset.name,
@@ -139,6 +134,15 @@ const makeAssetNamer = function (logger, asset) {
       callback(null);
     });
   };
+};
+
+/**
+ * @description Consistenty assemble an asset filename from a local path and a fingerprint.
+ */
+const fingerprinted = exports.fingerprinted = function (pathname, fingerprint) {
+  const ext = path.extname(pathname);
+  const basename = path.basename(pathname, ext);
+  return `${basename}-${fingerprint}${ext}`;
 };
 
 /**

--- a/src/routes/content/check.js
+++ b/src/routes/content/check.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Test for the existence of metadata envelopes by fingerprint
+
+const restify = require('restify');
+const storage = require('../../storage');
+
+exports.handler = function (req, res, next) {
+  const contentIDMap = req.body;
+
+  storage.envelopesExist(contentIDMap, (err, results) => {
+    if (err) {
+      req.logger.handleError('Unable to query content with fingerprints', err);
+      return next(new restify.errors.InternalServerError('Unable to query content fingerprints'));
+    }
+
+    res.send(results);
+    req.logger.reportSuccess('Content ID fingerprint query', {
+      envelopeCount: Object.keys(contentIDMap).length
+    });
+    next();
+  });
+};

--- a/src/routes/content/check.js
+++ b/src/routes/content/check.js
@@ -2,6 +2,7 @@
 
 // Test for the existence of metadata envelopes by fingerprint
 
+const _ = require('lodash');
 const restify = require('restify');
 const request = require('request');
 const urljoin = require('urljoin');
@@ -10,96 +11,128 @@ const storage = require('../../storage');
 const removeRevisionID = require('./retrieve').removeRevisionID;
 
 exports.handler = function (req, res, next) {
-  const contentIDMap = req.body;
+  const fingerprints = req.body;
 
-  storage.envelopesExist(contentIDMap, (err, existence) => {
+  storage.envelopesExist(fingerprints, (err, existence) => {
     if (err) {
       req.logger.handleError('Unable to query content with fingerprints', err);
       return next(new restify.errors.InternalServerError('Unable to query content fingerprints'));
     }
 
-    const results = {};
-    for (var contentID in existence) {
-      if (existence.hasOwnProperty(contentID)) {
-        results[contentID] = existence[contentID].present && existence[contentID].matches;
-      }
-    }
+    const localResults = _.mapValues(existence, (e) => e.present && e.matches);
 
-    const complete = () => {
+    const complete = (results) => {
       res.send(results);
       req.logger.reportSuccess('Content ID fingerprint query', {
-        envelopeCount: Object.keys(contentIDMap).length
+        envelopeCount: Object.keys(fingerprints).length
       });
       next();
     };
 
     if (config.proxyUpstream()) {
-      const url = urljoin(config.proxyUpstream(), 'checkcontent');
-
-      // Query upstream for all envelopes that are not present locally. Exclude any that were
-      // present but had different fingerprints. Remove the initial path segment when in staging
-      // mode, but track the mapping of modified content IDs to original ones.
-      const query = {};
-      const queryMapping = {};
-      for (let contentID in existence) {
-        if (existence.hasOwnProperty(contentID)) {
-          if (!existence[contentID].present) {
-            if (config.stagingMode()) {
-              const upstreamID = removeRevisionID(contentID);
-
-              // Remember which original contentID this upstreamID maps to. If multiple content IDs
-              // map to the same upstream ID, return an error.
-              if (upstreamID in queryMapping) {
-                req.logger.warn('Duplicate upstream content ID in upstream content fingerprint query', {
-                  contentID,
-                  upstreamID,
-                  statusCode: 400
-                });
-                return next(new restify.errors.BadRequestError('Multiple content IDs mapped to single upstream content ID'));
-              }
-              queryMapping[upstreamID] = contentID;
-
-              query[upstreamID] = contentIDMap[contentID];
-            } else {
-              query[contentID] = contentIDMap[contentID];
-            }
-          }
+      const query = { existence, fingerprints: {} };
+      _.forOwn(fingerprints, (fingerprint, contentID) => {
+        if (!existence[contentID].present) {
+          query.fingerprints[contentID] = fingerprint;
         }
-      }
-
-      req.logger.debug('Making an upstream content fingerprint query', {
-        url,
-        queryCount: Object.keys(query).length
       });
 
-      request({ url, body: query, json: true }, (err, response, body) => {
-        if (err) {
-          req.logger.reportError('Unable to query upstream with content fingerprints.', err);
-          return next(new restify.errors.BadGatewayError('Unable to query upstream for content fingerprints'));
-        }
-
-        if (response.statusCode !== 200) {
-          req.logger.reportError('Non-200 status from upstream content fingerprint check.');
-          return next(new restify.errors.BadGatewayError('Unable to query upstream for content fingerprints'));
-        }
-
-        // Merge in upstream results. When in staging mode, use queryMapping to report results
-        // in terms of the original query values.
-        for (let contentID in body) {
-          if (body.hasOwnProperty(contentID) && body[contentID]) {
-            if (config.stagingMode()) {
-              const originalID = queryMapping[contentID];
-              results[originalID] = true;
-            } else {
-              results[contentID] = true;
-            }
-          }
-        }
-
-        complete();
+      checkUpstream(req.logger, query, (err, upresults) => {
+        if (err) return next(err);
+        complete(_.assign(localResults, upresults));
       });
     } else {
-      complete();
+      complete(localResults);
+    }
+  });
+};
+
+/**
+ * @description Query an upstream content store for any envelopes that were not present locally.
+ * When staging mode is active as well, translate content IDs from the query by removing the
+ * initial path segment, then retranslate result IDs back to the original content IDs.
+ *
+ * If multiple content IDs from the query map to the same upstream content ID, a separate,
+ * recursive upstream query will be performed with the conflicting content IDs. Its results will
+ * merged in with this call's before the callback is invoked.
+ *
+ * Structure of the "query" parameter:
+ *
+ * {
+ *  existence: { <contentID>: { present: <Boolean>, matches: <Boolean> } },
+ *  fingerprints: { <contentID>: <fingerprint> }
+ * }
+ */
+const checkUpstream = function (logger, query, callback) {
+  const url = urljoin(config.proxyUpstream(), 'checkcontent');
+
+  const payload = {};
+  const mapping = {};
+  const subquery = {
+    existence: query.existence,
+    fingerprints: {}
+  };
+
+  for (let contentID in query.fingerprints) {
+    if (query.fingerprints.hasOwnProperty(contentID)) {
+      if (!query.existence[contentID].present) {
+        if (config.stagingMode()) {
+          const upstreamID = removeRevisionID(contentID);
+
+          // Remember the original contentID this upstreamID maps to. If multiple content IDs
+          // map to the same upstream ID, skip subsequent ones and instead begin constructing a
+          // subquery.
+          if (upstreamID in mapping) {
+            subquery.fingerprints[contentID] = query.fingerprints[contentID];
+          } else {
+            mapping[upstreamID] = contentID;
+            payload[upstreamID] = query.fingerprints[contentID];
+          }
+        } else {
+          // When not in staging mode, no contentID translation is necessary.
+          payload[contentID] = query.fingerprints[contentID];
+        }
+      }
+    }
+  }
+
+  logger.debug('Making an upstream content fingerprint query', {
+    url,
+    queryCount: Object.keys(payload).length
+  });
+
+  request({ url, body: payload, json: true }, (err, response, body) => {
+    if (err) {
+      logger.reportError('Unable to query upstream with content fingerprints.', err);
+      return callback(new restify.errors.BadGatewayError('Unable to query upstream for content fingerprints'));
+    }
+
+    if (response.statusCode !== 200) {
+      logger.reportError('Non-200 status from upstream content fingerprint check.', null, {
+        statusCode: response.statusCode
+      });
+
+      return callback(new restify.errors.BadGatewayError('Unable to query upstream for content fingerprints'));
+    }
+
+    let results = body;
+    if (config.stagingMode()) {
+      // When in staging mode, use the stored mapping to report results in terms of the original
+      // query contentIDs.
+      results = _.mapKeys(body, (v, upstreamID) => mapping[upstreamID]);
+    }
+
+    // Perform additional queries for ambiguous contentIDs if required.
+    if (Object.keys(subquery.fingerprints).length > 0) {
+      checkUpstream(logger, subquery, (err, subresults) => {
+        if (err) return callback(err);
+
+        // Merge subquery results into this query's.
+        callback(null, _.assign(results, subresults));
+      });
+    } else {
+      // No subquery necessary. Report directly.
+      callback(null, results);
     }
   });
 };

--- a/src/routes/content/check.js
+++ b/src/routes/content/check.js
@@ -3,21 +3,76 @@
 // Test for the existence of metadata envelopes by fingerprint
 
 const restify = require('restify');
+const request = require('request');
+const urljoin = require('urljoin');
+const config = require('../../config');
 const storage = require('../../storage');
 
 exports.handler = function (req, res, next) {
   const contentIDMap = req.body;
 
-  storage.envelopesExist(contentIDMap, (err, results) => {
+  storage.envelopesExist(contentIDMap, (err, existence) => {
     if (err) {
       req.logger.handleError('Unable to query content with fingerprints', err);
       return next(new restify.errors.InternalServerError('Unable to query content fingerprints'));
     }
 
-    res.send(results);
-    req.logger.reportSuccess('Content ID fingerprint query', {
-      envelopeCount: Object.keys(contentIDMap).length
-    });
-    next();
+    const results = {};
+    for (var contentID in existence) {
+      if (existence.hasOwnProperty(contentID)) {
+        results[contentID] = existence[contentID].present && existence[contentID].matches;
+      }
+    }
+
+    const complete = () => {
+      res.send(results);
+      req.logger.reportSuccess('Content ID fingerprint query', {
+        envelopeCount: Object.keys(contentIDMap).length
+      });
+      next();
+    };
+
+    if (config.proxyUpstream()) {
+      const url = urljoin(config.proxyUpstream(), 'checkcontent');
+
+      // Query upstream for all envelopes that are not present locally. Exclude any that were
+      // present but had different fingerprints.
+      const query = {};
+      for (let contentID in existence) {
+        if (existence.hasOwnProperty(contentID)) {
+          if (!existence[contentID].present) {
+            query[contentID] = contentIDMap[contentID];
+          }
+        }
+      }
+
+      req.logger.debug('Making an upstream content fingerprint query', {
+        url,
+        queryCount: Object.keys(query).length
+      });
+
+      request({ url, body: query, json: true }, (err, response, body) => {
+        if (err) {
+          req.logger.reportError('Unable to query upstream with content fingerprints.', err);
+          return next(new restify.errors.BadGatewayError('Unable to query upstream for content fingerprints'));
+        }
+
+        if (response.statusCode !== 200) {
+          req.logger.reportError('Non-200 status from upstream content fingerprint check.');
+          return next(new restify.errors.BadGatewayError('Unable to query upstream for content fingerprints'));
+        }
+
+        // Merge in upstream results.
+        for (let contentID in body) {
+          if (body.hasOwnProperty(contentID) && body[contentID]) {
+            results[contentID] = true;
+          }
+        }
+
+        complete();
+      });
+    } else {
+      complete();
+    }
   });
 };

--- a/src/routes/content/check.js
+++ b/src/routes/content/check.js
@@ -37,10 +37,14 @@ exports.handler = function (req, res, next) {
         }
       });
 
-      checkUpstream(req.logger, query, (err, upresults) => {
-        if (err) return next(err);
-        complete(_.assign(localResults, upresults));
-      });
+      if (Object.keys(query).length > 0) {
+        checkUpstream(req.logger, query, (err, upResults) => {
+          if (err) return next(err);
+          complete(_.assign(localResults, upResults));
+        });
+      } else {
+        complete(localResults);
+      }
     } else {
       complete(localResults);
     }

--- a/src/routes/content/index.js
+++ b/src/routes/content/index.js
@@ -3,4 +3,5 @@
 exports.store = require('./store').handler;
 exports.bulk = require('./bulk').handler;
 exports.retrieve = require('./retrieve').handler;
+exports.check = require('./check').handler;
 exports.remove = require('./remove').handler;

--- a/src/routes/content/retrieve.js
+++ b/src/routes/content/retrieve.js
@@ -105,7 +105,7 @@ exports.handler = function (req, res, next) {
 };
 
 // Remove the revision ID from the first path segment of the contentID.
-const removeRevisionID = function (contentID) {
+const removeRevisionID = exports.removeRevisionID = function (contentID) {
   let asURL = url.parse(contentID);
 
   let pathSegments = asURL.pathname.split('/');

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -17,6 +17,7 @@ exports.loadRoutes = function (server) {
   server.put('/content/:id', auth.requireKey, restify.bodyParser(), content.store);
   server.del('/content/:id', auth.requireKey, content.remove);
   server.post('/bulkcontent', auth.requireKey, content.bulk);
+  server.get('/checkcontent', restify.bodyParser({ requestBodyOnGet: true }), content.check);
 
   server.get('/assets', assets.list);
   server.get('/assets/:id', assets.retrieve);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -22,6 +22,7 @@ exports.loadRoutes = function (server) {
   server.get('/assets/:id', assets.retrieve);
   server.post('/assets', auth.requireKey, restify.bodyParser(), restify.queryParser(), assets.store);
   server.post('/bulkasset', auth.requireKey, restify.queryParser(), assets.bulk);
+  server.get('/checkassets', restify.bodyParser({ requestBodyOnGet: true }), assets.check);
 
   server.get('/search', restify.queryParser(), search.query);
 

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -25,6 +25,7 @@ var delegates = exports.delegates = [
   '_getEnvelope',
   'deleteEnvelope',
   'bulkDeleteEnvelopes',
+  'envelopesExist',
   'listEnvelopes',
   'createNewIndex',
   '_indexEnvelope',

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -16,6 +16,7 @@ var delegates = exports.delegates = [
   'bulkStoreAssets',
   'nameAsset',
   'findNamedAssets',
+  'assetExists',
   'getAsset',
   'storeKey',
   'deleteKey',

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,12 +1,16 @@
+'use strict';
+
 /**
  * Interfaces between the API and the underlying storage engines.
  */
 
-var cheerio = require('cheerio');
-var config = require('../config');
-var memory = require('./memory');
-var remote = require('./remote');
-var logger = require('../logging').getLogger();
+const crypto = require('crypto');
+const cheerio = require('cheerio');
+const stringify = require('json-stable-stringify');
+const config = require('../config');
+const memory = require('./memory');
+const remote = require('./remote');
+const logger = require('../logging').getLogger();
 
 // Methods to delegate to the activated storage driver.
 var delegates = exports.delegates = [
@@ -88,9 +92,14 @@ exports.setup = function (callback) {
 // Facade functions to perform common input preprocessing.
 
 exports.storeEnvelope = function (contentID, envelope, callback) {
+  const sha256sum = crypto.createHash('sha256');
+  sha256sum.update(stringify(envelope));
+  const fingerprint = sha256sum.digest('hex');
+
   const doc = {
     contentID,
     envelope,
+    fingerprint,
     lastUpdated: Date.now()
   };
 

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -156,9 +156,15 @@ MemoryStorage.prototype.envelopesExist = function (contentIDMap, callback) {
       const envelope = this.envelopes[contentID];
 
       if (!envelope) {
-        results[contentID] = false;
+        results[contentID] = {
+          present: false,
+          matches: false
+        };
       } else {
-        results[contentID] = envelope.fingerprint === contentIDMap[contentID];
+        results[contentID] = {
+          present: true,
+          matches: envelope.fingerprint === contentIDMap[contentID]
+        };
       }
     }
   }

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -77,6 +77,10 @@ MemoryStorage.prototype.findNamedAssets = function (callback) {
   callback(null, _.values(this.namedAssets));
 };
 
+MemoryStorage.prototype.assetExists = function (filename, callback) {
+  process.nextTick(() => callback(null, this.assets[filename] !== undefined));
+};
+
 MemoryStorage.prototype.getAsset = function (filename, callback) {
   var asset = this.assets[filename];
 

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -148,6 +148,24 @@ MemoryStorage.prototype.bulkDeleteEnvelopes = function (contentIDs, callback) {
   async.each(contentIDs, (id, cb) => this.deleteEnvelope(id, cb), callback);
 };
 
+MemoryStorage.prototype.envelopesExist = function (contentIDMap, callback) {
+  const results = {};
+
+  for (let contentID in contentIDMap) {
+    if (contentIDMap.hasOwnProperty(contentID)) {
+      const envelope = this.envelopes[contentID];
+
+      if (!envelope) {
+        results[contentID] = false;
+      } else {
+        results[contentID] = envelope.fingerprint === contentIDMap[contentID];
+      }
+    }
+  }
+
+  process.nextTick(() => callback(null, results));
+};
+
 MemoryStorage.prototype.listEnvelopes = function (prefix, eachCallback, endCallback) {
   var ids = Object.keys(this.envelopes);
 

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -332,6 +332,20 @@ RemoteStorage.prototype.bulkDeleteEnvelopes = function (contentIDs, callback) {
   mongoCollection('envelopes').bulkWrite(ops, options, callback);
 };
 
+RemoteStorage.prototype.envelopesExist = function (contentIDMap, callback) {
+  const query = { contentID: { $in: Object.keys(contentIDMap) } };
+  const projection = { contentID: 1, fingerprint: 1 };
+
+  const results = Object.keys(contentIDMap).reduce((object, contentID) => {
+    object[contentID] = false;
+    return object;
+  }, {});
+
+  mongoCollection('envelopes').find(query).project(projection).forEach((envelope) => {
+    results[envelope.contentID] = envelope.fingerprint === contentIDMap[envelope.contentID];
+  }, (err) => callback(err, results));
+};
+
 RemoteStorage.prototype.listEnvelopes = function (prefix, eachCallback, endCallback) {
   let filter = {};
 

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -332,17 +332,24 @@ RemoteStorage.prototype.bulkDeleteEnvelopes = function (contentIDs, callback) {
   mongoCollection('envelopes').bulkWrite(ops, options, callback);
 };
 
+/**
+ * @description Query for the existence and fingerprint matches of a set of content IDs. The result
+ * object will have the structure:
+ *
+ * { contentID: { present: Boolean, matches: Boolean }}
+ */
 RemoteStorage.prototype.envelopesExist = function (contentIDMap, callback) {
   const query = { contentID: { $in: Object.keys(contentIDMap) } };
   const projection = { contentID: 1, fingerprint: 1 };
 
   const results = Object.keys(contentIDMap).reduce((object, contentID) => {
-    object[contentID] = false;
+    object[contentID] = { present: false, matches: false };
     return object;
   }, {});
 
   mongoCollection('envelopes').find(query).project(projection).forEach((envelope) => {
-    results[envelope.contentID] = envelope.fingerprint === contentIDMap[envelope.contentID];
+    results[envelope.contentID].present = true;
+    results[envelope.contentID].matches = envelope.fingerprint === contentIDMap[envelope.contentID];
   }, (err) => callback(err, results));
 };
 

--- a/test/assets.js
+++ b/test/assets.js
@@ -137,7 +137,7 @@ describe('/bulkasset', function () {
   });
 });
 
-describe('/assetcheck', function () {
+describe('/checkassets', function () {
   beforeEach(resetHelper);
 
   beforeEach(function (done) {
@@ -149,9 +149,9 @@ describe('/assetcheck', function () {
     const finalName = storage.assetURLPrefix() + 'fake-asset-1234.txt';
 
     request(server.create())
-      .get('/assetcheck')
+      .get('/checkassets')
       .send({ 'path/fake-asset.txt': '1234', 'other/missing-asset.jpg': '4321' })
       .expect(200)
-      .expect({ assets: { 'path/fake-asset.txt': finalName, 'other/missing-asset.jpg': null } }, done);
+      .expect({ 'path/fake-asset.txt': finalName, 'other/missing-asset.jpg': null }, done);
   });
 });

--- a/test/content.js
+++ b/test/content.js
@@ -285,3 +285,36 @@ describe('/bulkcontent', function () {
     ], done);
   });
 });
+
+describe('/checkcontent', function () {
+  beforeEach(resetHelper);
+
+  beforeEach(function (done) {
+    storage.storeEnvelope('https://github.com/some/repo/path', {
+      title: 'one',
+      body: 'one one one'
+    }, done);
+  });
+  beforeEach(function (done) {
+    storage.storeEnvelope('https://github.com/some/repo/other', {
+      title: 'two',
+      body: 'two two two'
+    }, done);
+  });
+
+  it('reports true for each envelope that is present with a matching fingerprint', function (done) {
+    request(server.create())
+      .get('/checkcontent')
+      .send({
+        'https://github.com/some/repo/path': '',
+        'https://github.com/some/repo/other': '',
+        'https://github.com/some/repo/missing': ''
+      })
+      .expect(200)
+      .expect({
+        'https://github.com/some/repo/path': true,
+        'https://github.com/some/repo/other': false,
+        'https://github.com/some/repo/missing': false
+      }, done);
+  });
+});

--- a/test/content.js
+++ b/test/content.js
@@ -306,9 +306,9 @@ describe('/checkcontent', function () {
     request(server.create())
       .get('/checkcontent')
       .send({
-        'https://github.com/some/repo/path': '',
-        'https://github.com/some/repo/other': '',
-        'https://github.com/some/repo/missing': ''
+        'https://github.com/some/repo/path': 'f5ac32c93010b9d0a9f7ca98aab0c3daa80580f06e79d238065619948f435a7f',
+        'https://github.com/some/repo/other': '2aeb0c4381a573b85f44dc70ecef8c3b9f04c448c787223be43b15ed7146d440',
+        'https://github.com/some/repo/missing': '4df6be44e605e1123b3b98c27094b1515f518b8df3db7c77615f9c85e553a43a'
       })
       .expect(200)
       .expect({

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -72,7 +72,10 @@ describe('upstream', () => {
 
     it('merges /checkcontent results from upstream', (done) => {
       nock('https://upstream/')
-        .get('/checkcontent')
+        .get('/checkcontent', {
+          'https://github.com/remote/remote': 'b1b6e4c544880769b42bdbf7f6338cba3db78cf734424af20e5c4d30251a984c',
+          'https://github.com/remote/missing': '0ff459af6d050d72d642eeb3a1ea5a8a93fd518993ac56711bd86a7e49b95191'
+        })
         .reply(200, {
           'https://github.com/remote/remote': true,
           'https://github.com/remote/missing': false

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -177,7 +177,8 @@ describe('upstream', () => {
       // Note to self: this is still kind of awkward.
       let assets = [
         { name: 'only-local', filename: 'only-local-123123.jpg', type: 'image/jpg' },
-        { name: 'both', filename: 'both-456456.jpg', type: 'image/jpg' }
+        { name: 'both-right', filename: 'both-right-789789.jpg', type: 'image/jpg' },
+        { name: 'both-wrong', filename: 'both-wrong-111111.jpg', type: 'image/jpg' }
       ];
 
       let storeEach = (asset, cb) => {
@@ -196,7 +197,8 @@ describe('upstream', () => {
       nock('https://upstream')
         .get('/assets').reply(200, {
           'only-upstream': 'https://assets.horse/up/only-upstream-123123.jpg',
-          'both': 'https://assets.horse/up/both-321321.jpg'
+          'both-right': 'https://assets.horse/up/both-789789.jpg',
+          'both-wrong': 'https://assets.horse/up/both-wrong-111111.jpg'
         });
 
       request(server.create())
@@ -207,7 +209,8 @@ describe('upstream', () => {
         .expect({
           'only-upstream': 'https://assets.horse/up/only-upstream-123123.jpg',
           'only-local': storage.assetURLPrefix() + 'only-local-123123.jpg',
-          'both': storage.assetURLPrefix() + 'both-456456.jpg'
+          'both-right': storage.assetURLPrefix() + 'both-right-789789.jpg',
+          'both-wrong': storage.assetURLPrefix() + 'both-wrong-111111.jpg'
         }, done);
     });
 

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -142,17 +142,31 @@ describe('upstream', () => {
           }, done);
       });
 
-      it('returns a /checkcontent error if the upstream query is ambiguous', (done) => {
+      it('supports /checkcontent queries for ambiguous upstream content', (done) => {
+        nock('https://upstream/')
+          .get('/checkcontent', {
+            'https://github.com/remote/remote': 'b1b6e4c544880769b42bdbf7f6338cba3db78cf734424af20e5c4d30251a984c'
+          })
+          .reply(200, {
+            'https://github.com/remote/remote': true
+          })
+          .get('/checkcontent', {
+            'https://github.com/remote/remote': '0ff459af6d050d72d642eeb3a1ea5a8a93fd518993ac56711bd86a7e49b95191'
+          })
+          .reply(200, {
+            'https://github.com/remote/remote': false
+          });
+
         request(server.create())
           .get('/checkcontent')
           .send({
             'https://github.com/build-123456/remote/remote': 'b1b6e4c544880769b42bdbf7f6338cba3db78cf734424af20e5c4d30251a984c',
             'https://github.com/build-654321/remote/remote': '0ff459af6d050d72d642eeb3a1ea5a8a93fd518993ac56711bd86a7e49b95191'
           })
-          .expect(400)
+          .expect(200)
           .expect({
-            code: 'BadRequestError',
-            message: 'Multiple content IDs mapped to single upstream content ID'
+            'https://github.com/build-123456/remote/remote': true,
+            'https://github.com/build-654321/remote/remote': false
           }, done);
       });
     });


### PR DESCRIPTION
Create API endpoints to support bulk queries of assets and envelopes by SHA-256 digest fingerprint.
- [x] `/checkassets`
- [x] `/checkcontent`
- [x] upstream support for `/checkassets`
- [x] upstream and proxy mode support for `/checkcontent`
- [x] handle ambiguous upstream content IDs correctly
- [x] README documentation
