### PR TITLE
Incorrect asset fingerprint checks with URL-encoded filenames

### DIFF
--- a/src/routes/assets/bulk.js
+++ b/src/routes/assets/bulk.js
@@ -46,7 +46,7 @@ exports.handler = function (req, res, next) {
       const name = `${bname}-${sha256sum.digest('hex')}${ext}`;
 
       assetCount++;
-      publicURLs[entryPath] = storage.assetURLPrefix() + encodeURIComponent(name);
+      publicURLs[entryPath] = storage.assetPublicURL(name);
 
       pack.entry({ name }, body);
       req.logger.debug('Repacked asset', { entryPath, name, assetCount });

--- a/src/routes/assets/check.js
+++ b/src/routes/assets/check.js
@@ -38,7 +38,7 @@ exports.handler = function (req, res, next) {
       }
 
       if (exists) {
-        localResults[assetFilename] = storage.assetURLPrefix() + internalName;
+        localResults[assetFilename] = storage.assetURLPrefix() + encodeURIComponent(internalName);
       } else {
         localResults[assetFilename] = null;
       }

--- a/src/routes/assets/check.js
+++ b/src/routes/assets/check.js
@@ -38,7 +38,7 @@ exports.handler = function (req, res, next) {
       }
 
       if (exists) {
-        localResults[assetFilename] = storage.assetURLPrefix() + encodeURIComponent(internalName);
+        localResults[assetFilename] = storage.assetPublicURL(internalName);
       } else {
         localResults[assetFilename] = null;
       }

--- a/src/routes/assets/store.js
+++ b/src/routes/assets/store.js
@@ -121,7 +121,7 @@ const makeAssetPublisher = function (logger, asset) {
 };
 
 /**
- * @description Give this asset a name. The final name and CDL URI of this
+ * @description Give this asset a name. The final name and CDN URI of this
  *   asset will be included in all outgoing metadata envelopes, for use by
  *   layouts.
  */

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -16,6 +16,7 @@ const logger = require('../logging').getLogger();
 var delegates = exports.delegates = [
   'clear',
   'assetURLPrefix',
+  'assetPublicURL',
   'storeAsset',
   'bulkStoreAssets',
   'nameAsset',

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -35,12 +35,16 @@ MemoryStorage.prototype.assetURLPrefix = function () {
   return '/__local_asset__/';
 };
 
+MemoryStorage.prototype.assetPublicURL = function (filename) {
+  return this.assetURLPrefix() + encodeURIComponent(filename);
+};
+
 MemoryStorage.prototype.storeAsset = function (stream, filename, contentType, callback) {
   getRawBody(stream, (err, body) => {
     if (err) return callback(err);
 
     this.assets[filename] = { contentType, body };
-    const publicURL = this.assetURLPrefix() + encodeURIComponent(filename);
+    const publicURL = this.assetPublicURL(filename);
 
     callback(null, publicURL);
   });

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -73,6 +73,13 @@ RemoteStorage.prototype.assetURLPrefix = function () {
 };
 
 /**
+ * @description Return the public CDN URL of a (possibly hypothetical) asset filename.
+ */
+RemoteStorage.prototype.assetPublicURL = function (filename) {
+  return this.assetURLPrefix() + encodeURIComponent(filename);
+};
+
+/**
  * @description Upload an asset to the Cloud Files asset container.
  */
 RemoteStorage.prototype.storeAsset = function (stream, filename, contentType, callback) {
@@ -88,7 +95,7 @@ RemoteStorage.prototype.storeAsset = function (stream, filename, contentType, ca
   up.on('error', callback);
 
   up.on('success', () => {
-    const publicURL = this.assetURLPrefix() + encodeURIComponent(filename);
+    const publicURL = this.assetPublicURL(filename);
     callback(null, publicURL);
   });
 
@@ -133,7 +140,7 @@ RemoteStorage.prototype.findNamedAssets = function (callback) {
  * @description Yield true if an asset exists or false if it does not.
  */
 RemoteStorage.prototype.assetExists = function (filename, callback) {
-  const u = this.assetURLPrefix() + encodeURIComponent(filename);
+  const u = this.assetPublicURL(filename);
 
   request({ url: u, method: 'HEAD' }, (err, response, body) => {
     if (err) return callback(err);

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -133,7 +133,7 @@ RemoteStorage.prototype.findNamedAssets = function (callback) {
  * @description Yield true if an asset exists or false if it does not.
  */
 RemoteStorage.prototype.assetExists = function (filename, callback) {
-  const u = this.assetURLPrefix() + filename;
+  const u = this.assetURLPrefix() + encodeURIComponent(filename);
 
   request({ url: u, method: 'HEAD' }, (err, response, body) => {
     if (err) return callback(err);

--- a/test/assets.js
+++ b/test/assets.js
@@ -145,6 +145,11 @@ describe('/checkassets', function () {
     storage.storeAsset(stream, 'fake-asset-1234.txt', 'text/plain', done);
   });
 
+  beforeEach(function (done) {
+    const stream = streamifier.createReadStream('another');
+    storage.storeAsset(stream, 'This%20file%20is%20url-encoded-9999.txt', 'text/plain', done);
+  });
+
   it("returns the publicURL for each asset that exists and null for those that don't", function (done) {
     const finalName = storage.assetURLPrefix() + 'fake-asset-1234.txt';
 
@@ -153,5 +158,15 @@ describe('/checkassets', function () {
       .send({ 'path/fake-asset.txt': '1234', 'other/missing-asset.jpg': '4321' })
       .expect(200)
       .expect({ 'path/fake-asset.txt': finalName, 'other/missing-asset.jpg': null }, done);
+  });
+
+  it('verifies the correct filename for assets that with URL-encoded names', function (done) {
+    const finalName = storage.assetURLPrefix() + 'This%2520file%2520is%2520url-encoded-9999.txt';
+
+    request(server.create())
+      .get('/checkassets')
+      .send({ 'path/This%20file%20is%20url-encoded.txt': '9999' })
+      .expect(200)
+      .expect({ 'path/This%20file%20is%20url-encoded.txt': finalName }, done);
   });
 });

--- a/test/assets.js
+++ b/test/assets.js
@@ -10,6 +10,7 @@ require('./helpers/before');
 const chai = require('chai');
 const dirtyChai = require('dirty-chai');
 chai.use(dirtyChai);
+const expect = chai.expect;
 
 const fs = require('fs');
 const path = require('path');
@@ -32,7 +33,7 @@ describe('/assets', function () {
 
   beforeEach(resetHelper);
   beforeEach(function () {
-    finalName = storage.assetURLPrefix() + fingerprintedFilename;
+    finalName = storage.assetPublicURL(fingerprintedFilename);
   });
 
   it('accepts an asset file and produces a fingerprinted filename', function (done) {
@@ -151,7 +152,7 @@ describe('/checkassets', function () {
   });
 
   it("returns the publicURL for each asset that exists and null for those that don't", function (done) {
-    const finalName = storage.assetURLPrefix() + 'fake-asset-1234.txt';
+    const finalName = storage.assetPublicURL('fake-asset-1234.txt');
 
     request(server.create())
       .get('/checkassets')
@@ -161,7 +162,9 @@ describe('/checkassets', function () {
   });
 
   it('verifies the correct filename for assets that with URL-encoded names', function (done) {
-    const finalName = storage.assetURLPrefix() + 'This%2520file%2520is%2520url-encoded-9999.txt';
+    const finalName = storage.assetPublicURL('This%20file%20is%20url-encoded-9999.txt');
+
+    expect(finalName).to.match(/\/This%2520file%2520is%2520url-encoded-9999\.txt$/);
 
     request(server.create())
       .get('/checkassets')

--- a/test/assets.js
+++ b/test/assets.js
@@ -161,7 +161,7 @@ describe('/checkassets', function () {
       .expect({ 'path/fake-asset.txt': finalName, 'other/missing-asset.jpg': null }, done);
   });
 
-  it('verifies the correct filename for assets that with URL-encoded names', function (done) {
+  it('verifies the correct filename for assets that have URL-encoded names', function (done) {
     const finalName = storage.assetPublicURL('This%20file%20is%20url-encoded-9999.txt');
 
     expect(finalName).to.match(/\/This%2520file%2520is%2520url-encoded-9999\.txt$/);

--- a/test/upstream.js
+++ b/test/upstream.js
@@ -208,9 +208,9 @@ describe('upstream', () => {
         .expect('Content-Type', 'application/json')
         .expect({
           'only-upstream': 'https://assets.horse/up/only-upstream-123123.jpg',
-          'only-local': storage.assetURLPrefix() + 'only-local-123123.jpg',
-          'both-right': storage.assetURLPrefix() + 'both-right-789789.jpg',
-          'both-wrong': storage.assetURLPrefix() + 'both-wrong-111111.jpg'
+          'only-local': storage.assetPublicURL('only-local-123123.jpg'),
+          'both-right': storage.assetPublicURL('both-right-789789.jpg'),
+          'both-wrong': storage.assetPublicURL('both-wrong-111111.jpg')
         }, done);
     });
 
@@ -234,9 +234,9 @@ describe('upstream', () => {
         })
         .expect(200)
         .expect({
-          'somepath/only-local.jpg': storage.assetURLPrefix() + 'only-local-123123.jpg',
+          'somepath/only-local.jpg': storage.assetPublicURL('only-local-123123.jpg'),
           'otherpath/only-upstream.jpg': 'https://assets.horse/up/only-upstream-456456.jpg',
-          'more/paths/both-right.jpg': storage.assetURLPrefix() + 'both-right-789789.jpg',
+          'more/paths/both-right.jpg': storage.assetPublicURL('both-right-789789.jpg'),
           'both-wrong.jpg': null
         }, done);
     });


### PR DESCRIPTION
`/checkassets` is inconsistent with `/bulkasset` (and `POST /assets`) in its treatment of filenames that are already URL-encoded.

On asset upload, the filename of the asset on the CDN is _double_ URL-encoded, even though the asset filename within the tarball is not:

```
Uploading /usr/content-repo/_site/deconst-assets/exchange/manually-configure-android-devices-for-email-hosted-on-exchange-2013/2.%20Accounts%20and%20Sync_2.png as exchange/manually-configure-android-devices-for-email-hosted-on-exchange-2013/2.%20Accounts%20and%20Sync_2.png
```

``` json
{
  ".../2.%20Accounts%20and%20Sync_2.png": "https://...rackcdn.com/2.%2520Accounts%2520and%2520Sync_2-905591f06054d66b76dabe9f500324aa42f62e659444b42603d1b6051782e163.png"
}
```

This is consistent with assets uploaded individually to `POST /assets`:

``` bash
$ curl -X POST -H "Authorization: deconst ${ADMIN_APIKEY}" http://dockerdev:9000/assets/ -F exchange/manually-configure-android-devices-for-email-hosted-on-exchange-2013/2.%20Accounts%20and%20Sync_2.png=@_site/deconst-assets/exchange/manually-configure-android-devices-for-email-hosted-on-exchange-2013/2.%20Accounts%20and%20Sync_2.png
```

``` json
{
  "2.%20Accounts%20and%20Sync_2.png": "https:/...rackcdn.com/2.%2520Accounts%2520and%2520Sync_2-905591f06054d66b76dabe9f500324aa42f62e659444b42603d1b6051782e163.png"}
```

It also matches how the file actually appears on the CDN:

``` bash
$ headers https://0713ef7983f29a83b126-de204993f903c565093efc9471abc1cb.ssl.cf5.rackcdn.com/2.%2520Accounts%2520and%2520Sync_2-905591f06054d66b76dabe9f500324aa42f62e659444b42603d1b6051782e163.png
GET /2.%2520Accounts%2520and%2520Sync_2-905591f06054d66b76dabe9f500324aa42f62e659444b42603d1b6051782e163.png HTTP/1.1
Host: 0713ef7983f29a83b126-de204993f903c565093efc9471abc1cb.ssl.cf5.rackcdn.com
User-Agent: curl/7.43.0
Accept: */*

HTTP/1.1 200 OK
Content-Length: 35948
Accept-Ranges: bytes
Last-Modified: Thu, 28 Apr 2016 14:27:10 GMT
ETag: 6e2bcddc3b886f39e866c141eabcb267
X-Timestamp: 1461853629.70053
Access-Control-Allow-Origin: *
Content-Type: application/octet-stream
X-Trans-Id: txd98ceb3e72004e73a9fed-0057221e14iad3
Cache-Control: public, max-age=31535980
Expires: Fri, 28 Apr 2017 14:28:16 GMT
Date: Thu, 28 Apr 2016 14:28:36 GMT
Connection: keep-alive

[1517 bytes data]
```

However, `/checkassets` doesn't recognize the asset as present:

_(Request)_

``` json
{
  ".../2.%20Accounts%20and%20Sync_2.png": "905591f06054d66b76dabe9f500324aa42f62e659444b42603d1b6051782e163"
}
```

_(Response)_

``` json
{
  ".../2.%20Accounts%20and%20Sync_2.png": null
}
```

Related to deconst/submitter#11.
