### PR TITLE
Bulk deletion by content ID prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,13 @@ The request payload must be a valid Deconst metadata envelope in JSON form.
 
 An HTTP status of 200 and an empty response body will be returned when content is accepted successfully.
 
-### `DELETE /content/:id`
+### `DELETE /content/:id[?prefix=true]`
 
 **(Authorization required: any user)**
 
-Delete content with a specific URL-encoded *content ID*.
+Delete content with a specific URL-encoded *content ID*. If '?prefix=true' is specified, delete *all content* with a content ID with the `:id` parameter as a prefix.
+
+:warning: Use caution when bulk-deleting content from production. Ensure that no other mapped content that you *don't* wish to delete shares a prefix with the `:id` you provide. :warning:
 
 *Response: Successful*
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -15,7 +15,7 @@ exports.loadRoutes = function (server) {
 
   server.get('/content/:id', content.retrieve);
   server.put('/content/:id', auth.requireKey, restify.bodyParser(), content.store);
-  server.del('/content/:id', auth.requireKey, content.remove);
+  server.del('/content/:id', auth.requireKey, restify.queryParser(), content.remove);
   server.post('/bulkcontent', auth.requireKey, content.bulk);
   server.get('/checkcontent', restify.bodyParser({ requestBodyOnGet: true }), content.check);
 

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -246,7 +246,7 @@ MemoryStorage.prototype.unindexEnvelope = function (contentID, callback) {
 };
 
 MemoryStorage.prototype.bulkUnindexEnvelopes = function (contentIDs, callback) {
-  async.each(contentIDs, (id, cb) => this.unindexEnvelopes(id, cb), callback);
+  async.each(contentIDs, (id, cb) => this.unindexEnvelope(id, cb), callback);
 };
 
 MemoryStorage.prototype.storeSHA = function (sha, callback) {

--- a/test/content.js
+++ b/test/content.js
@@ -192,12 +192,7 @@ describe('/content', function () {
         .end(function (err, res) {
           if (err) return done(err);
 
-          storage.getEnvelope('https://one/aaa', function (err, uploaded) {
-            expect(err).not.to.be.null();
-            expect(err.statusCode).to.equal(404);
-
-            done();
-          });
+          expectNoEnvelope('https://one/aaa')(done);
         });
     });
 

--- a/test/content.js
+++ b/test/content.js
@@ -213,6 +213,22 @@ describe('/content', function () {
           });
         });
     });
+
+    it('deletes all content with a content ID prefix', function (done) {
+      request(server.create())
+        .delete('/content/https%3A%2F%2Fone%2F?prefix=true')
+        .set('Authorization', authHelper.AUTH_USER)
+        .expect(204)
+        .end((err, res) => {
+          if (err) return done(err);
+
+          async.parallel([
+            expectNoEnvelope('https://one/aaa'),
+            expectNoEnvelope('https://one/bbb'),
+            expectStoredEnvelope('https://two/aaa', { body: 'third' })
+          ], done);
+        });
+    });
   });
 });
 


### PR DESCRIPTION
When `?prefix=true` is provided on a content deletion call, delete all envelopes whose content ID is a prefix of the `:id` parameter.
