### PR TITLE
List envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ Report the service name, version, and git commit.
 }
 ```
 
+### `GET /content/:id[?prefix=:id_prefix&pageNumber=:num&perPage=:size]`
+
+List content IDs available within the content service, paginated. If `:id_prefix` is provided, list only content IDs beginning with that prefix.
+
+The default page size is 100 content IDs.
+
+*Response: Successful*
+
+On success, the response includes an HTTP status of 200 and contains a JSON payload containing zero to many matching content IDs.
+
+```json
+{
+  "total": 123,
+  "results": [
+    {
+      "contentID": "<matching content ID>",
+      "url": "<API URL to fetch envelope contents>"
+    }
+  ]
+}
+```
+
 ### `PUT /content/:id`
 
 **(Authorization required: any user)**

--- a/src/routes/content/bulk.js
+++ b/src/routes/content/bulk.js
@@ -118,9 +118,7 @@ exports.handler = function (req, res, next) {
 
     let existingContentIDs = [];
 
-    storage.listEnvelopes(contentIDBase, (err, doc) => {
-      if (err) return cb(err);
-
+    storage.listEnvelopes({ prefix: contentIDBase }, (doc) => {
       existingContentIDs.push(doc.contentID);
     }, (err) => {
       if (err) return cb(err);

--- a/src/routes/content/index.js
+++ b/src/routes/content/index.js
@@ -4,4 +4,5 @@ exports.store = require('./store').handler;
 exports.bulk = require('./bulk').handler;
 exports.retrieve = require('./retrieve').handler;
 exports.check = require('./check').handler;
+exports.list = require('./list').handler;
 exports.remove = require('./remove').handler;

--- a/src/routes/content/list.js
+++ b/src/routes/content/list.js
@@ -1,0 +1,7 @@
+'use strict';
+
+exports.handler = function (req, res, next) {
+  req.logger.debug('Content list requested.');
+
+  res.send(200, {});
+};

--- a/src/routes/content/list.js
+++ b/src/routes/content/list.js
@@ -16,9 +16,7 @@ exports.handler = function (req, res, next) {
 
   async.parallel({
     total: (cb) => storage.countEnvelopes({}, cb),
-    results: (cb) => storage.listEnvelopes(null, (err, each) => {
-      if (err) return handleError('Unable to retrieve envelope', err);
-
+    results: (cb) => storage.listEnvelopes({}, (each) => {
       results.push({
         contentID: each.contentID,
         url: `/content/${encodeURIComponent(each.contentID)}`

--- a/src/routes/content/list.js
+++ b/src/routes/content/list.js
@@ -4,19 +4,23 @@ const async = require('async');
 const storage = require('../../storage');
 
 exports.handler = function (req, res, next) {
-  req.logger.debug('Content list requested.');
+  const options = {
+    prefix: req.query.prefix
+  };
+
+  req.logger.debug('Content list requested.', options);
 
   const results = [];
 
   const handleError = (message, err) => {
     err.statusCode = err.status = 500;
-    req.logger.reportError(message, err);
+    req.logger.reportError(message, err, { payload: options });
     return next(err);
   };
 
   async.parallel({
-    total: (cb) => storage.countEnvelopes({}, cb),
-    results: (cb) => storage.listEnvelopes({}, (each) => {
+    total: (cb) => storage.countEnvelopes(options, cb),
+    results: (cb) => storage.listEnvelopes(options, (each) => {
       results.push({
         contentID: each.contentID,
         url: `/content/${encodeURIComponent(each.contentID)}`

--- a/src/routes/content/list.js
+++ b/src/routes/content/list.js
@@ -1,7 +1,28 @@
 'use strict';
 
+const storage = require('../../storage');
+
 exports.handler = function (req, res, next) {
   req.logger.debug('Content list requested.');
 
-  res.send(200, {});
+  const results = [];
+
+  const handleError = (message, err) => {
+    err.statusCode = err.status = 500;
+    req.logger.reportError(message, err);
+    return next(err);
+  };
+
+  storage.listEnvelopes(null, (err, each) => {
+    if (err) return handleError('Unable to retrieve envelope', err);
+
+    results.push({
+      contentID: each.contentID,
+      url: `/content/${encodeURIComponent(each.contentID)}`
+    });
+  }, (err) => {
+    if (err) return handleError('Unable to enumerate envelopes', err);
+
+    res.send(200, { total: 0, results });
+  });
 };

--- a/src/routes/content/list.js
+++ b/src/routes/content/list.js
@@ -5,10 +5,22 @@ const storage = require('../../storage');
 
 exports.handler = function (req, res, next) {
   const options = {
+    prefix: req.query.prefix,
+    perPage: req.query.perPage || 100,
+    pageNumber: req.query.pageNumber || 1
+  };
+
+  const listOptions = {
+    prefix: options.prefix,
+    skip: (options.pageNumber - 1) * options.perPage,
+    limit: options.perPage
+  };
+
+  const countOptions = {
     prefix: req.query.prefix
   };
 
-  req.logger.debug('Content list requested.', options);
+  req.logger.debug('Content list requested.', { options });
 
   const results = [];
 
@@ -19,8 +31,8 @@ exports.handler = function (req, res, next) {
   };
 
   async.parallel({
-    total: (cb) => storage.countEnvelopes(options, cb),
-    results: (cb) => storage.listEnvelopes(options, (each) => {
+    total: (cb) => storage.countEnvelopes(countOptions, cb),
+    results: (cb) => storage.listEnvelopes(listOptions, (each) => {
       results.push({
         contentID: each.contentID,
         url: `/content/${encodeURIComponent(each.contentID)}`

--- a/src/routes/content/remove.js
+++ b/src/routes/content/remove.js
@@ -33,9 +33,7 @@ exports.handler = function (req, res, next) {
     completeRemoval([contentID]);
   } else {
     const contentIDs = [];
-    storage.listEnvelopes(contentID, (err, envelope) => {
-      if (err) return handleError(err, 'Unable to list envelopes.');
-
+    storage.listEnvelopes({ prefix: contentID }, (envelope) => {
       contentIDs.push(envelope.contentID);
     }, (err) => {
       if (err) return handleError(err, 'Unable to list envelopes.');

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -13,6 +13,7 @@ var search = require('./search');
 exports.loadRoutes = function (server) {
   server.get('/version', version.report);
 
+  server.get('/content', content.list);
   server.get('/content/:id', content.retrieve);
   server.put('/content/:id', auth.requireKey, restify.bodyParser(), content.store);
   server.del('/content/:id', auth.requireKey, restify.queryParser(), content.remove);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -13,7 +13,7 @@ var search = require('./search');
 exports.loadRoutes = function (server) {
   server.get('/version', version.report);
 
-  server.get('/content', content.list);
+  server.get('/content', restify.queryParser(), content.list);
   server.get('/content/:id', content.retrieve);
   server.put('/content/:id', auth.requireKey, restify.bodyParser(), content.store);
   server.del('/content/:id', auth.requireKey, restify.queryParser(), content.remove);

--- a/src/routes/reindex.js
+++ b/src/routes/reindex.js
@@ -48,14 +48,8 @@ function reindex (logger) {
   };
 
   let reindexAllContent = function (callback) {
-    storage.listEnvelopes(null, (err, doc) => {
+    storage.listEnvelopes({}, (doc) => {
       state.totalEnvelopes++;
-
-      if (err) {
-        state.failedEnvelopes++;
-        return handleError(err, 'Unable to list content', true);
-      }
-
       logger.debug('Reindexing envelope', { contentID: doc.contentID });
 
       storage.indexEnvelope(doc.contentID, doc.envelope, indexName, (err) => {

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -32,6 +32,7 @@ var delegates = exports.delegates = [
   'bulkDeleteEnvelopes',
   'envelopesExist',
   'listEnvelopes',
+  'countEnvelopes',
   'createNewIndex',
   '_indexEnvelope',
   'makeIndexActive',

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -177,7 +177,7 @@ MemoryStorage.prototype.envelopesExist = function (contentIDMap, callback) {
 };
 
 MemoryStorage.prototype._matchingIDs = function (options) {
-  let ids = Object.keys(this.envelopes);
+  let ids = Object.keys(this.envelopes).sort();
 
   if (options.prefix) {
     ids = ids.filter((id) => id.startsWith(options.prefix));

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -176,14 +176,14 @@ MemoryStorage.prototype.envelopesExist = function (contentIDMap, callback) {
   process.nextTick(() => callback(null, results));
 };
 
-MemoryStorage.prototype.listEnvelopes = function (prefix, eachCallback, endCallback) {
+MemoryStorage.prototype.listEnvelopes = function (options, eachCallback, endCallback) {
   var ids = Object.keys(this.envelopes);
 
-  if (prefix) {
-    ids = ids.filter((id) => id.startsWith(prefix));
+  if (options.prefix) {
+    ids = ids.filter((id) => id.startsWith(options.prefix));
   }
 
-  ids.forEach((id) => eachCallback(null, this.envelopes[id]));
+  ids.forEach((id) => eachCallback(this.envelopes[id]));
 
   endCallback(null);
 };

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -183,6 +183,14 @@ MemoryStorage.prototype._matchingIDs = function (options) {
     ids = ids.filter((id) => id.startsWith(options.prefix));
   }
 
+  if (options.skip) {
+    ids = ids.slice(options.skip);
+  }
+
+  if (options.limit) {
+    ids = ids.slice(0, options.limit);
+  }
+
   return ids;
 };
 

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -188,6 +188,16 @@ MemoryStorage.prototype.listEnvelopes = function (prefix, eachCallback, endCallb
   endCallback(null);
 };
 
+MemoryStorage.prototype.countEnvelopes = function (options, callback) {
+  let ids = Object.keys(this.envelopes);
+
+  if (options.prefix) {
+    ids = ids.filter((id) => id.startsWith(options.prefix));
+  }
+
+  process.nextTick(() => callback(null, ids.length));
+};
+
 MemoryStorage.prototype.createNewIndex = function (indexName, callback) {
   callback();
 };

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -176,25 +176,23 @@ MemoryStorage.prototype.envelopesExist = function (contentIDMap, callback) {
   process.nextTick(() => callback(null, results));
 };
 
-MemoryStorage.prototype.listEnvelopes = function (options, eachCallback, endCallback) {
-  var ids = Object.keys(this.envelopes);
-
-  if (options.prefix) {
-    ids = ids.filter((id) => id.startsWith(options.prefix));
-  }
-
-  ids.forEach((id) => eachCallback(this.envelopes[id]));
-
-  endCallback(null);
-};
-
-MemoryStorage.prototype.countEnvelopes = function (options, callback) {
+MemoryStorage.prototype._matchingIDs = function (options) {
   let ids = Object.keys(this.envelopes);
 
   if (options.prefix) {
     ids = ids.filter((id) => id.startsWith(options.prefix));
   }
 
+  return ids;
+};
+
+MemoryStorage.prototype.listEnvelopes = function (options, eachCallback, endCallback) {
+  this._matchingIDs(options).forEach((id) => eachCallback(this.envelopes[id]));
+  process.nextTick(() => endCallback(null));
+};
+
+MemoryStorage.prototype.countEnvelopes = function (options, callback) {
+  const ids = this._matchingIDs(options);
   process.nextTick(() => callback(null, ids.length));
 };
 

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -280,7 +280,12 @@ RemoteStorage.prototype._envelopeCursor = function (options) {
     filter = { contentID: { $regex: `^${options.prefix}` } };
   }
 
-  return mongoCollection('envelopes').find(filter);
+  let cursor = mongoCollection('envelopes').find(filter);
+
+  if (options.skip) cursor = cursor.skip(options.skip);
+  if (options.limit) cursor = cursor.limit(options.limit);
+
+  return cursor;
 };
 
 RemoteStorage.prototype.listEnvelopes = function (options, eachCallback, endCallback) {

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -273,17 +273,24 @@ RemoteStorage.prototype.envelopesExist = function (contentIDMap, callback) {
   }, (err) => callback(err, results));
 };
 
-RemoteStorage.prototype.listEnvelopes = function (prefix, eachCallback, endCallback) {
+RemoteStorage.prototype._envelopeCursor = function (options) {
   let filter = {};
 
-  if (prefix) {
-    filter = { contentID: { $regex: `^${prefix}` } };
+  if (options.prefix) {
+    filter = { contentID: { $regex: `^${options.prefix}` } };
   }
 
-  const iter = (doc) => eachCallback(null, doc);
-  const end = (err) => endCallback(err);
+  return mongoCollection('envelopes').find(filter);
+};
 
-  mongoCollection('envelopes').find(filter).forEach(iter, end);
+RemoteStorage.prototype.listEnvelopes = function (prefix, eachCallback, endCallback) {
+  const iter = (doc) => eachCallback(null, doc);
+
+  this._envelopeCursor({ prefix }).forEach(iter, endCallback);
+};
+
+RemoteStorage.prototype.countEnvelopes = function (options, callback) {
+  this._envelopeCursor(options).count(true, callback);
 };
 
 RemoteStorage.prototype.createNewIndex = function (indexName, callback) {

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -283,10 +283,8 @@ RemoteStorage.prototype._envelopeCursor = function (options) {
   return mongoCollection('envelopes').find(filter);
 };
 
-RemoteStorage.prototype.listEnvelopes = function (prefix, eachCallback, endCallback) {
-  const iter = (doc) => eachCallback(null, doc);
-
-  this._envelopeCursor({ prefix }).forEach(iter, endCallback);
+RemoteStorage.prototype.listEnvelopes = function (options, eachCallback, endCallback) {
+  this._envelopeCursor(options).forEach(eachCallback, endCallback);
 };
 
 RemoteStorage.prototype.countEnvelopes = function (options, callback) {

--- a/test/content.js
+++ b/test/content.js
@@ -252,6 +252,19 @@ describe('/content', function () {
         .expect(200)
         .expect({ total: 20, results }, done);
     });
+
+    it('limits results by a prefix', (done) => {
+      request(server.create())
+        .get('/content/?prefix=https%3A%2F%2Fbase%2F1')
+        .expect(200)
+        .expect({
+          total: 2,
+          results: [
+            { contentID: 'https://base/1', url: '/content/https%3A%2F%2Fbase%2F1' },
+            { contentID: 'https://base/10', url: '/content/https%3A%2F%2Fbase%2F10' }
+          ]
+        }, done);
+    });
   });
 });
 

--- a/test/content.js
+++ b/test/content.js
@@ -238,14 +238,19 @@ describe('/content', function () {
       }, done);
     });
 
-    it('enumerates stored envelopes', (done) => {
-      const results = [];
-      for (let i = 0; i < 20; i++) {
-        results.push({
+    const constructResults = function (numbers) {
+      return numbers.map((i) => {
+        return {
           contentID: `https://base/${i}`,
           url: `/content/https%3A%2F%2Fbase%2F${i}`
-        });
-      }
+        };
+      });
+    };
+
+    it('enumerates stored envelopes', (done) => {
+      const results = constructResults([
+        0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 3, 4, 5, 6, 7, 8, 9
+      ]);
 
       request(server.create())
         .get('/content/')
@@ -254,12 +259,7 @@ describe('/content', function () {
     });
 
     it('limits results by a prefix', (done) => {
-      const results = [1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19].map((i) => {
-        return {
-          contentID: `https://base/${i}`,
-          url: `/content/https%3A%2F%2Fbase%2F${i}`
-        };
-      });
+      const results = constructResults([1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
 
       request(server.create())
         .get('/content/?prefix=https%3A%2F%2Fbase%2F1')

--- a/test/content.js
+++ b/test/content.js
@@ -266,6 +266,15 @@ describe('/content', function () {
         .expect(200)
         .expect({ total: 11, results }, done);
     });
+
+    it('accepts basic pagination', (done) => {
+      const results = constructResults([14, 15, 16, 17, 18]);
+
+      request(server.create())
+        .get('/content?prefix=https%3A%2F%2Fbase%2F1&pageNumber=2&perPage=5')
+        .expect(200)
+        .expect({ total: 11, results }, done);
+    });
   });
 });
 

--- a/test/content.js
+++ b/test/content.js
@@ -230,6 +230,29 @@ describe('/content', function () {
         });
     });
   });
+
+  describe('#list', () => {
+    beforeEach((done) => {
+      async.times(20, (i, next) => {
+        storeAndIndexEnvelope(`https://base/${i}`, { body: i.toString() })(next);
+      }, done);
+    });
+
+    it('enumerates stored envelopes', (done) => {
+      const results = [];
+      for (let i = 0; i < 20; i++) {
+        results.push({
+          contentID: `https://base/${i}`,
+          url: `/content/https%3A%2F%2Fbase%2F${i}`
+        });
+      }
+
+      request(server.create())
+        .get('/content/')
+        .expect(200)
+        .expect({ total: 20, results }, done);
+    });
+  });
 });
 
 describe('/bulkcontent', function () {

--- a/test/content.js
+++ b/test/content.js
@@ -254,16 +254,17 @@ describe('/content', function () {
     });
 
     it('limits results by a prefix', (done) => {
+      const results = [1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19].map((i) => {
+        return {
+          contentID: `https://base/${i}`,
+          url: `/content/https%3A%2F%2Fbase%2F${i}`
+        };
+      });
+
       request(server.create())
         .get('/content/?prefix=https%3A%2F%2Fbase%2F1')
         .expect(200)
-        .expect({
-          total: 2,
-          results: [
-            { contentID: 'https://base/1', url: '/content/https%3A%2F%2Fbase%2F1' },
-            { contentID: 'https://base/10', url: '/content/https%3A%2F%2Fbase%2F10' }
-          ]
-        }, done);
+        .expect({ total: 11, results }, done);
     });
   });
 });


### PR DESCRIPTION
Deleting envelopes is a lot more dangerous if you can't see which envelopes are there to be deleted. Implement a `GET /content/` endpoint to list known content IDs.
- [x] First pass: list absolutely everything.
- [x] Filter by a prefix.
- [x] Pagination, consistently with the way it works for `/search`.
- [x] Document the new endpoint in the README.
