### PR TITLE
Configurable URL prefix for in-memory assets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ The content service is configured by passing environment variables to the Docker
  * `MONGODB_PREFIX`: **(default: `""`)** Prefix used to partition MongoDB collection names from other services using the same MongoDB database.
  * `ELASTICSEARCH_HOST`: **(required if STORAGE=remote)** Elasticsearch connection string, including any required authentication information.
 
+### Memory storage
+
+ * `MEMORY_ASSET_PREFIX`: **(default: `"/__local_asset__/"`)** Prefix used to construct URLs for assets present in memory storage.
+
 ### Staging
 
  * `STAGING_MODE`: *(default: `"false"`)* Act as a staging store, to stage many revisions of content simultaneously. When staging mode is active, proxied content IDs will have their first URL path segment, the revision ID, removed when making the upstream request.

--- a/src/config.js
+++ b/src/config.js
@@ -32,6 +32,10 @@ const configuration = {
   assetContainer: {
     env: 'ASSET_CONTAINER'
   },
+  memoryAssetPrefix: {
+    env: 'MEMORY_ASSET_PREFIX',
+    def: '/__local_asset__/'
+  },
   mongodbURL: {
     env: 'MONGODB_URL'
   },

--- a/src/routes/assets/store.js
+++ b/src/routes/assets/store.js
@@ -127,7 +127,7 @@ const makeAssetPublisher = function (logger, asset) {
  */
 const makeAssetNamer = function (logger, asset) {
   return (callback) => {
-    storage.nameAsset(asset.name, asset.publicURL, (err, asset) => {
+    storage.nameAsset(asset.name, asset.publicURL, (err) => {
       if (err) return callback(err);
 
       logger.debug('Asset named successfully.', { assetName: asset.name });

--- a/src/storage/memory.js
+++ b/src/storage/memory.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const async = require('async');
 const getRawBody = require('raw-body');
 const tar = require('tar-stream');
+const config = require('../config');
 
 /**
  * @description Storage driver that uses entirely in-memory data structures.
@@ -32,7 +33,7 @@ MemoryStorage.prototype.clear = function (callback) {
  * @description Return prefix of the URL that assets are served under.
  */
 MemoryStorage.prototype.assetURLPrefix = function () {
-  return '/__local_asset__/';
+  return config.memoryAssetPrefix();
 };
 
 MemoryStorage.prototype.assetPublicURL = function (filename) {

--- a/test/config.js
+++ b/test/config.js
@@ -36,6 +36,7 @@ describe('config', () => {
     expect(config.mongodbURL()).to.be.undefined();
 
     expect(config.rackspaceServiceNet()).to.be.false();
+    expect(config.memoryAssetPrefix()).to.equal('/__local_asset__/');
     expect(config.elasticsearchHost()).to.be.null();
     expect(config.contentLogLevel()).to.equal('info');
     expect(config.contentLogColor()).to.be.false();
@@ -54,6 +55,7 @@ describe('config', () => {
       ADMIN_APIKEY: '12345',
       CONTENT_CONTAINER: 'the-content-container',
       ASSET_CONTAINER: 'the-asset-container',
+      MEMORY_ASSET_PREFIX: 'http://localhost:9000/',
       MONGODB_URL: 'mongodb-url',
       MONGODB_PREFIX: 'foo-',
       ELASTICSEARCH_HOST: 'https://elasticsearch:9200/',
@@ -70,6 +72,7 @@ describe('config', () => {
     expect(config.adminAPIKey()).to.equal('12345');
     expect(config.contentContainer()).to.equal('the-content-container');
     expect(config.assetContainer()).to.equal('the-asset-container');
+    expect(config.memoryAssetPrefix()).to.equal('http://localhost:9000/');
     expect(config.mongodbURL()).to.equal('mongodb-url');
     expect(config.mongodbPrefix()).to.equal('foo-');
     expect(config.elasticsearchHost()).to.equal('https://elasticsearch:9200/');

--- a/test/helpers/before.js
+++ b/test/helpers/before.js
@@ -30,6 +30,7 @@ function reconfigure (overrides) {
       ADMIN_APIKEY: process.env.ADMIN_APIKEY || '12345',
       CONTENT_CONTAINER: 'the-content-container',
       ASSET_CONTAINER: 'the-asset-container',
+      MEMORY_ASSET_PREFIX: '/__asset_prefix__/',
       MONGODB_URL: 'mongodb-url',
       CONTENT_LOG_LEVEL: process.env.CONTENT_LOG_LEVEL || 'fatal'
     }, overrides));


### PR DESCRIPTION
Accept a URL prefix for assets when in-memory storage is enabled. This will be useful for local rendering with deconst/integrated.
