### PR TITLE
adding a TTL-enabled kv pair

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -104,7 +104,7 @@ exports.storeEnvelope = function (contentID, envelope, callback) {
     envelope,
     fingerprint,
     lastUpdated: Date.now(),
-    updateTTL: new Date()
+    dateForTTL: new Date()
   };
 
   exports._storeEnvelope(contentID, doc, callback);

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -103,7 +103,8 @@ exports.storeEnvelope = function (contentID, envelope, callback) {
     contentID,
     envelope,
     fingerprint,
-    lastUpdated: Date.now()
+    lastUpdated: Date.now(),
+    updateTTL: new Date()
   };
 
   exports._storeEnvelope(contentID, doc, callback);


### PR DESCRIPTION
Mongo's [TTL index](https://docs.mongodb.com/manual/core/index-ttl/) needs a BSON date, which is [generated](https://docs.mongodb.com/manual/reference/method/Date/) by the [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object. Just adding another field rather than modifying the lastUpdated field to preserve any other dependencies.

Fixes #87 