### PR TITLE
[WIP] - Upgrade elasticsearch support to 6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async": "2.0.0-rc.2",
     "cheerio": "^0.19.0",
-    "elasticsearch": "^9.0.2",
+    "elasticsearch": "^14.1.0",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^3.8.0",
     "mongodb": "2.0.27",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "content-service",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A content service for storing and retreiving content",
   "main": "app.js",
   "scripts": {

--- a/src/storage/connection.js
+++ b/src/storage/connection.js
@@ -116,7 +116,7 @@ function elasticInit (callback) {
 
   const client = new elasticsearch.Client({
     host: config.elasticsearchHost(),
-    apiVersion: '1.7',
+    apiVersion: '6.2',
     ssl: { rejectUnauthorized: true }, // Plz no trivial MITM attacks
     log: ElasticLogs,
     maxRetries: Infinity

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -377,7 +377,7 @@ RemoteStorage.prototype.queryEnvelopes = function (query, categories, pageNumber
   } else {
     q.bool = {
       must: {
-        match: { all : query },
+        match: { all: query },
         filter: { terms: { categories: categories } }
       }
     };

--- a/src/storage/remote.js
+++ b/src/storage/remote.js
@@ -301,10 +301,10 @@ RemoteStorage.prototype.createNewIndex = function (indexName, callback) {
 
   let envelopeMapping = {
     properties: {
-      title: { type: 'string', index: 'analyzed' },
-      body: { type: 'string', index: 'analyzed' },
-      keywords: { type: 'string', index: 'analyzed' },
-      categories: { type: 'string', index: 'not_analyzed' }
+      title: { type: 'text', index: true, copy_to: 'all' },
+      body: { type: 'text', index: true, copy_to: 'all' },
+      keywords: { type: 'text', index: true, copy_to: 'all' },
+      categories: { type: 'text', index: false, copy_to: 'all' }
     }
   };
 
@@ -347,8 +347,7 @@ RemoteStorage.prototype.makeIndexActive = function (indexName, callback) {
 
     connection.elastic.indices.get({
       index: 'envelopes*',
-      ignoreUnavailable: true,
-      feature: '_settings'
+      ignoreUnavailable: true
     }, (err, response, status) => {
       if (err) return callback(err);
 
@@ -374,11 +373,13 @@ RemoteStorage.prototype.queryEnvelopes = function (query, categories, pageNumber
   const q = {};
 
   if (!categories) {
-    q.match = { _all: query };
+    q.match = { all: query };
   } else {
-    q.filtered = {
-      query: { match: { _all: query } },
-      filter: { terms: { categories: categories } }
+    q.bool = {
+      must: {
+        match: { all : query },
+        filter: { terms: { categories: categories } }
+      }
     };
   }
 


### PR DESCRIPTION
This includes the necessary changes to support the latest version of Elasticsearch. It required updating the npm package as well as updating how searches are performed.

fixes #127
fixes #123
